### PR TITLE
awsutil: add GetCallerIdentity

### DIFF
--- a/awsutil/options.go
+++ b/awsutil/options.go
@@ -3,6 +3,7 @@ package awsutil
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/hashicorp/go-hclog"
@@ -40,6 +41,7 @@ type options struct {
 	withMaxRetries             *int
 	withRegion                 string
 	withHttpClient             *http.Client
+	withTimeout                time.Duration
 }
 
 func getDefaultOptions() options {
@@ -156,6 +158,15 @@ func WithMaxRetries(with *int) Option {
 func WithHttpClient(with *http.Client) Option {
 	return func(o *options) error {
 		o.withHttpClient = with
+		return nil
+	}
+}
+
+// WithTimeout allows passing a timeout for operations that can wait
+// on success.
+func WithTimeout(with time.Duration) Option {
+	return func(o *options) error {
+		o.withTimeout = with
 		return nil
 	}
 }

--- a/awsutil/options_test.go
+++ b/awsutil/options_test.go
@@ -3,6 +3,7 @@ package awsutil
 import (
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -111,5 +112,10 @@ func Test_GetOpts(t *testing.T) {
 		opts, err := getOpts(WithHttpClient(client))
 		require.NoError(t, err)
 		assert.Equal(t, &opts.withHttpClient, &client)
+	})
+	t.Run("withTimeout", func(t *testing.T) {
+		opts, err := getOpts(WithTimeout(time.Second))
+		require.NoError(t, err)
+		assert.Equal(t, opts.withTimeout, time.Second)
 	})
 }

--- a/awsutil/rotate_test.go
+++ b/awsutil/rotate_test.go
@@ -52,3 +52,49 @@ func TestRotation(t *testing.T) {
 	assert.NotEqual(secretKey, c.SecretKey)
 	cleanupKey = &c.AccessKey
 }
+
+func TestCallerIdentity(t *testing.T) {
+	require, assert := require.New(t), assert.New(t)
+
+	key, secretKey, sessionToken := os.Getenv("AWS_ACCESS_KEY_ID"), os.Getenv("AWS_SECRET_ACCESS_KEY"), os.Getenv("AWS_SESSION_TOKEN")
+	if key == "" || secretKey == "" {
+		t.Skip("missing AWS_ACCESS_KEY_ID or AWS_SECRET_ACCESS_KEY")
+	}
+
+	c := &CredentialsConfig{
+		AccessKey:    key,
+		SecretKey:    secretKey,
+		SessionToken: sessionToken,
+	}
+
+	cid, err := c.GetCallerIdentity()
+	require.NoError(err)
+	assert.NotEmpty(cid.Account)
+	assert.NotEmpty(cid.Arn)
+	assert.NotEmpty(cid.UserId)
+}
+
+func TestCallerIdentityWithSession(t *testing.T) {
+	require, assert := require.New(t), assert.New(t)
+
+	key, secretKey, sessionToken := os.Getenv("AWS_ACCESS_KEY_ID"), os.Getenv("AWS_SECRET_ACCESS_KEY"), os.Getenv("AWS_SESSION_TOKEN")
+	if key == "" || secretKey == "" {
+		t.Skip("missing AWS_ACCESS_KEY_ID or AWS_SECRET_ACCESS_KEY")
+	}
+
+	c := &CredentialsConfig{
+		AccessKey:    key,
+		SecretKey:    secretKey,
+		SessionToken: sessionToken,
+	}
+
+	sess, err := c.GetSession()
+	require.NoError(err)
+	require.NotNil(sess)
+
+	cid, err := c.GetCallerIdentity(WithAwsSession(sess))
+	require.NoError(err)
+	assert.NotEmpty(cid.Account)
+	assert.NotEmpty(cid.Arn)
+	assert.NotEmpty(cid.UserId)
+}


### PR DESCRIPTION
This adds the GetCallerIdentity call, which allows for a set of
credentials/session to get information on its effective account ID and
principal ARN.

This can be useful in checking the validity of credentials, as it
requires no permissions to run other than the access key to be usable.

For info on the call, see:
  https://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html