### PR TITLE
awsutil: add GetCallerIdentity to Create/Rotate

### DIFF
--- a/awsutil/options.go
+++ b/awsutil/options.go
@@ -41,7 +41,7 @@ type options struct {
 	withMaxRetries             *int
 	withRegion                 string
 	withHttpClient             *http.Client
-	withTimeout                time.Duration
+	withValidityCheckTimeout   time.Duration
 }
 
 func getDefaultOptions() options {
@@ -162,11 +162,11 @@ func WithHttpClient(with *http.Client) Option {
 	}
 }
 
-// WithTimeout allows passing a timeout for operations that can wait
+// WithValidityCheckTimeout allows passing a timeout for operations that can wait
 // on success.
-func WithTimeout(with time.Duration) Option {
+func WithValidityCheckTimeout(with time.Duration) Option {
 	return func(o *options) error {
-		o.withTimeout = with
+		o.withValidityCheckTimeout = with
 		return nil
 	}
 }

--- a/awsutil/options_test.go
+++ b/awsutil/options_test.go
@@ -113,9 +113,9 @@ func Test_GetOpts(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, &opts.withHttpClient, &client)
 	})
-	t.Run("withTimeout", func(t *testing.T) {
-		opts, err := getOpts(WithTimeout(time.Second))
+	t.Run("withValidityCheckTimeout", func(t *testing.T) {
+		opts, err := getOpts(WithValidityCheckTimeout(time.Second))
 		require.NoError(t, err)
-		assert.Equal(t, opts.withTimeout, time.Second)
+		assert.Equal(t, opts.withValidityCheckTimeout, time.Second)
 	})
 }

--- a/awsutil/rotate_test.go
+++ b/awsutil/rotate_test.go
@@ -34,7 +34,7 @@ func TestRotation(t *testing.T) {
 	}
 
 	// Create an initial key
-	out, err := credsConfig.CreateAccessKey(WithUsername(username), WithTimeout(testRotationWaitTimeout))
+	out, err := credsConfig.CreateAccessKey(WithUsername(username), WithValidityCheckTimeout(testRotationWaitTimeout))
 	require.NoError(err)
 	require.NotNil(out)
 
@@ -51,7 +51,7 @@ func TestRotation(t *testing.T) {
 		WithSecretKey(secretKey),
 	)
 	require.NoError(err)
-	require.NoError(c.RotateKeys(WithTimeout(testRotationWaitTimeout)))
+	require.NoError(c.RotateKeys(WithValidityCheckTimeout(testRotationWaitTimeout)))
 	assert.NotEqual(accessKey, c.AccessKey)
 	assert.NotEqual(secretKey, c.SecretKey)
 	cleanupKey = &c.AccessKey
@@ -116,7 +116,7 @@ func TestCallerIdentityErrorNoTimeout(t *testing.T) {
 	require.Implements((*awserr.Error)(nil), err)
 }
 
-func TestCallerIdentityErrorWithTimeout(t *testing.T) {
+func TestCallerIdentityErrorWithValidityCheckTimeout(t *testing.T) {
 	require := require.New(t)
 
 	c := &CredentialsConfig{
@@ -124,7 +124,7 @@ func TestCallerIdentityErrorWithTimeout(t *testing.T) {
 		SecretKey: "badagain",
 	}
 
-	_, err := c.GetCallerIdentity(WithTimeout(time.Second * 10))
+	_, err := c.GetCallerIdentity(WithValidityCheckTimeout(time.Second * 10))
 	require.NotNil(err)
 	require.True(strings.HasPrefix(err.Error(), "timeout after 10s waiting for success"))
 	err = errors.Unwrap(err)

--- a/awsutil/rotate_test.go
+++ b/awsutil/rotate_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const testRotationWaitTimeout = time.Second * 30
+
 func TestRotation(t *testing.T) {
 	require, assert := require.New(t), assert.New(t)
 
@@ -32,7 +34,7 @@ func TestRotation(t *testing.T) {
 	}
 
 	// Create an initial key
-	out, err := credsConfig.CreateAccessKey(WithUsername(username))
+	out, err := credsConfig.CreateAccessKey(WithUsername(username), WithTimeout(testRotationWaitTimeout))
 	require.NoError(err)
 	require.NotNil(out)
 
@@ -49,8 +51,7 @@ func TestRotation(t *testing.T) {
 		WithSecretKey(secretKey),
 	)
 	require.NoError(err)
-	time.Sleep(10 * time.Second)
-	require.NoError(c.RotateKeys())
+	require.NoError(c.RotateKeys(WithTimeout(testRotationWaitTimeout)))
 	assert.NotEqual(accessKey, c.AccessKey)
 	assert.NotEqual(secretKey, c.SecretKey)
 	cleanupKey = &c.AccessKey


### PR DESCRIPTION
This adds GetCallerIdentity to CreateAccessKey and RotateKeys. The
latter is done simply by passing WithTimeout through to the inner
CreateAccessKey on Rotate. As such, both paths are conditional on a
non-zero WithTimeout option being given - this is to ensure that we
don't try to immediately verify, which is likely to always fail.