### PR TITLE
Read `AWS_PROFILE` to enable Shared Credentials provider

### DIFF
--- a/awsutil/generate_credentials.go
+++ b/awsutil/generate_credentials.go
@@ -180,6 +180,14 @@ func (c *CredentialsConfig) GenerateCredentialChain(opt ...Option) (*credentials
 		providers = append(providers, webIdentityProvider)
 	}
 
+	profile := os.Getenv("AWS_PROFILE")
+	if profile != "" {
+		c.Profile = profile
+	}
+	if c.Profile == "" {
+		c.Profile = "default"
+	}
+
 	if opts.withEnvironmentCredentials {
 		// Add the environment credential provider
 		providers = append(providers, &credentials.EnvProvider{})

--- a/awsutil/generate_credentials.go
+++ b/awsutil/generate_credentials.go
@@ -180,20 +180,19 @@ func (c *CredentialsConfig) GenerateCredentialChain(opt ...Option) (*credentials
 		providers = append(providers, webIdentityProvider)
 	}
 
-	profile := os.Getenv("AWS_PROFILE")
-	if profile != "" {
-		c.Profile = profile
-	}
-	if c.Profile == "" {
-		c.Profile = "default"
-	}
-
 	if opts.withEnvironmentCredentials {
 		// Add the environment credential provider
 		providers = append(providers, &credentials.EnvProvider{})
 	}
 
 	if opts.withSharedCredentials {
+		profile := os.Getenv("AWS_PROFILE")
+		if profile != "" {
+			c.Profile = profile
+		}
+		if c.Profile == "" {
+			c.Profile = "default"
+		}
 		// Add the shared credentials provider
 		providers = append(providers, &credentials.SharedCredentialsProvider{
 			Filename: c.Filename,


### PR DESCRIPTION
This PR uses the Profile field that already existed in the AWS Credentials Config. It reads from the `AWS_PROFILE` environment variable and uses this value in the `GenerateCredentialChain` method to enable the Shared Credentials Provider. 

The addition of these changes allows the use of `source_profile` fields that point to a named profile with credentials for assuming roles. This aims to fix:
- https://github.com/hashicorp/vault/issues/5767
- https://github.com/hashicorp/terraform-provider-vault/issues/1086 (TFVP issue related to above Vault issue)
