### PR TITLE
mlock: Remove android build tag

### DIFF
--- a/mlock/mlock_unavail.go
+++ b/mlock/mlock_unavail.go
@@ -1,4 +1,4 @@
-// +build android darwin nacl netbsd plan9 windows
+// +build darwin nacl netbsd plan9 windows
 
 package mlock
 


### PR DESCRIPTION
Using `GOOS=android` matches build tags and files as for `GOOS=linux` in addition to android tags and files.
See https://groups.google.com/g/golang-nuts/c/ZTGMjhEV7uY for further details.

Without this change when using `gomobile bind` I see the following error:
```
# github.com/hashicorp/go-secure-stdlib/mlock
../pkg/mod/github.com/hashicorp/go-secure-stdlib/mlock@v0.1.1/mlock_unix.go:15:6: lockMemory redeclared in this block
        /tmp/gomobile-work-2337392267/pkg/mod/github.com/hashicorp/go-secure-stdlib/mlock@v0.1.1/mlock_unavail.go:9:19: previous declaration
```