### PR TITLE
feature: Add support handling forwarded for headers 

### DIFF
--- a/listenerutil/error.go
+++ b/listenerutil/error.go
@@ -1,0 +1,9 @@
+package listenerutil
+
+import (
+	"errors"
+)
+
+var (
+	ErrInvalidParameter = errors.New("invalid parameter")
+)

--- a/listenerutil/forwarded_for.go
+++ b/listenerutil/forwarded_for.go
@@ -1,0 +1,192 @@
+package listenerutil
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/textproto"
+	"strings"
+
+	"github.com/hashicorp/go-sockaddr"
+)
+
+type key int
+
+const (
+	remoteAddrKey key = iota
+)
+
+// ErrResponseFn provides a func to call whenever WrapForwardedForHandler
+// encounters an error
+type ErrResponseFn func(w http.ResponseWriter, status int, err error)
+
+// WrapForwaredForHandler is an http middleware handler which uses the
+// XForwardedFor* listener config settings to determine how/if X-Forwarded-For
+// are trusted/allowed for an inbound request.  In the end, if a "trusted"
+// X-Forwarded-For header is found, then the request RemoteAddr will be
+// overwritten with it before the request is served.
+func WrapForwardedForHandler(h http.Handler, l *ListenerConfig, respErrFn ErrResponseFn) (http.Handler, error) {
+	if h == nil {
+		return nil, fmt.Errorf("missing http handler: %w", ErrInvalidParameter)
+	}
+	if l == nil {
+		return nil, fmt.Errorf("missing listener config: %w", ErrInvalidParameter)
+	}
+	if respErrFn == nil {
+		return nil, fmt.Errorf("missing response error function: %w", ErrInvalidParameter)
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		trusted, err := TrustedFromXForwardedFor(r, l)
+		if err != nil {
+			respErrFn(w, http.StatusBadRequest, err)
+			return
+		}
+		if trusted == nil {
+			h.ServeHTTP(w, r)
+			return
+		}
+		newCtx, err := newOrigRemoteAddrCtx(r.Context(), r.RemoteAddr)
+		if err != nil {
+			respErrFn(w, http.StatusBadRequest, fmt.Errorf("error setting orig remote header ctx: %w", err))
+			return
+		}
+		r = r.WithContext(newCtx)
+		r.RemoteAddr = net.JoinHostPort(trusted.Host, trusted.Port)
+		h.ServeHTTP(w, r)
+		return
+	}), nil
+}
+
+// Addr represents only the Host and Port of a TCP address.
+type Addr struct {
+	Host string
+	Port string
+}
+
+// TrustedFromXForwardedFor will use the XForwardedFor* listener config settings
+// to determine how/if X-Forwarded-For are trusted/allowed for an inbound
+// request.  Important: return values of nil, nil are valid and simply means
+// that no "trusted" header was found and no error was raised as well.  Errors
+// can be raised for a number of conditions based on the listener config
+// settings, especially when the config setting for
+// XForwardedForRejectNotPresent is set to true which means if a "trusted"
+// header can't be found the request should be rejected.
+func TrustedFromXForwardedFor(r *http.Request, l *ListenerConfig) (*Addr, error) {
+	if r == nil {
+		return nil, fmt.Errorf("missing http request: %w", ErrInvalidParameter)
+	}
+	if l == nil {
+		return nil, fmt.Errorf("missing listener config: %w", ErrInvalidParameter)
+	}
+	rejectNotPresent := l.XForwardedForRejectNotPresent
+	hopSkips := l.XForwardedForHopSkips
+	authorizedAddrs := l.XForwardedForAuthorizedAddrs
+	rejectNotAuthz := l.XForwardedForRejectNotAuthorized
+
+	headers, headersOK := r.Header[textproto.CanonicalMIMEHeaderKey("X-Forwarded-For")]
+	if !headersOK || len(headers) == 0 {
+		if !rejectNotPresent {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("missing x-forwarded-for header and configured to reject when not present")
+	}
+
+	host, port, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		// If not rejecting treat it like we just don't have a valid
+		// header because we can't do a comparison against an address we
+		// can't understand
+		if !rejectNotPresent {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("error parsing client hostport: %w", err)
+	}
+
+	addr, err := sockaddr.NewIPAddr(host)
+	if err != nil {
+		// We treat this the same as the case above
+		if !rejectNotPresent {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("error parsing client address: %w", err)
+	}
+
+	var found bool
+	for _, authz := range authorizedAddrs {
+		if authz.Contains(addr) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		// If we didn't find it and aren't configured to reject, simply
+		// don't trust it
+		if !rejectNotAuthz {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("client address not authorized for x-forwarded-for and configured to reject connection")
+	}
+
+	// At this point we have at least one value and it's authorized
+
+	// Split comma separated ones, which are common. This brings it in line
+	// to the multiple-header case.
+	var acc []string
+	for _, header := range headers {
+		vals := strings.Split(header, ",")
+		for _, v := range vals {
+			// validate the header contains a valid IP
+			v = strings.TrimSpace(v)
+			ip := net.ParseIP(v)
+			if ip == nil {
+				if !rejectNotPresent {
+					return nil, nil
+				}
+				return nil, fmt.Errorf("error parsing client address (%s) from header", v)
+			}
+			acc = append(acc, v)
+		}
+	}
+
+	indexToUse := int64(len(acc)) - 1 - hopSkips
+	if indexToUse < 0 {
+		// This is likely an error in either configuration or other
+		// infrastructure. We could either deny the request, or we
+		// could simply not trust the value. Denying the request is
+		// "safer" since if this logic is configured at all there may
+		// be an assumption it can always be trusted. Given that we can
+		// deny accepting the request at all if it's not from an
+		// authorized address, if we're at this point the address is
+		// authorized (or we've turned off explicit rejection) and we
+		// should assume that what comes in should be properly
+		// formatted.
+		return nil, fmt.Errorf("malformed x-forwarded-for configuration or request, hops to skip (%d) would skip before earliest chain link (chain length %d)", hopSkips, len(headers))
+	}
+
+	return &Addr{acc[indexToUse], port}, nil
+}
+
+// newOrigRemoteAddrCtx will return a context containing a value for the
+// provided original remote address
+func newOrigRemoteAddrCtx(ctx context.Context, origRemoteAddr string) (context.Context, error) {
+	const op = "event.NewRequestInfoContext"
+	if ctx == nil {
+		return nil, fmt.Errorf("%s: missing context: %w", op, ErrInvalidParameter)
+	}
+	if origRemoteAddr == "" {
+		return nil, fmt.Errorf("%s: missing original remote address: %w", op, ErrInvalidParameter)
+	}
+	return context.WithValue(ctx, remoteAddrKey, origRemoteAddr), nil
+}
+
+// OrigRemoteAddrFromCtx attempts to get the original remote address value from
+// the context provided
+func OrigRemoteAddrFromCtx(ctx context.Context) (string, bool) {
+	if ctx == nil {
+		return "", false
+	}
+	orig, ok := ctx.Value(remoteAddrKey).(string)
+	return orig, ok
+}

--- a/listenerutil/forwarded_for_test.go
+++ b/listenerutil/forwarded_for_test.go
@@ -353,7 +353,7 @@ func Test_TrustedFromXForwardedFor(t *testing.T) {
 			}(),
 			xForwardedFor: []string{"127.0.0.1:127"},
 			remoteAddr:    "127.0.0.1:22",
-			wantAddr:      &Addr{Host: "127.0.0.1", Port: "22"},
+			wantAddr:      &Addr{Host: "127.0.0.1", Port: "127"},
 			wantErr:       false,
 		},
 		{
@@ -398,7 +398,7 @@ func Test_TrustedFromXForwardedFor(t *testing.T) {
 					req.RemoteAddr = tt.remoteAddr
 				}
 			}
-			gotAddr, err := TrustedFromXForwardedFor(req, tt.listenerCfg)
+			gotTrusted, gotRemote, err := TrustedFromXForwardedFor(req, tt.listenerCfg)
 			if tt.wantErr {
 				require.Error(err)
 				if tt.wantErrContains != "" {
@@ -408,10 +408,14 @@ func Test_TrustedFromXForwardedFor(t *testing.T) {
 			}
 			require.NoError(err)
 			if tt.wantAddr != nil {
-				require.NotNil(gotAddr)
-				assert.Equal(tt.wantAddr, gotAddr)
+				require.NotNil(gotTrusted)
+				require.NotNil(gotRemote)
+				assert.NotEmpty(gotRemote.Host)
+				assert.NotEmpty(gotRemote.Port)
+				assert.Equal(tt.wantAddr, gotTrusted)
 			} else {
-				assert.Nil(gotAddr)
+				assert.Nil(gotTrusted)
+				assert.Nil(gotRemote)
 			}
 		})
 	}

--- a/listenerutil/forwarded_for_test.go
+++ b/listenerutil/forwarded_for_test.go
@@ -1,0 +1,466 @@
+package listenerutil
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/go-sockaddr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_WrapForwardedForHandler(t *testing.T) {
+	t.Parallel()
+	goodAddr, err := sockaddr.NewIPAddr("127.0.0.1")
+	require.NoError(t, err)
+
+	testErrResponseFn := func(w http.ResponseWriter, status int, err error) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+
+		type ErrorResponse struct {
+			Errors []string `json:"errors"`
+		}
+		resp := &ErrorResponse{Errors: make([]string, 0, 1)}
+		if err != nil {
+			resp.Errors = append(resp.Errors, err.Error())
+		}
+
+		enc := json.NewEncoder(w)
+		enc.Encode(resp)
+	}
+
+	badAddr, err := sockaddr.NewIPAddr("1.2.3.4")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name                   string
+		listenerCfg            *ListenerConfig
+		xForwardedFor          []string
+		errRespFn              ErrResponseFn
+		useNilHandler          bool
+		wantFactoryErr         bool
+		wantFactoryErrContains string
+		wantErr                bool
+		wantStatusCode         int
+		wantBodyContains       string
+	}{
+		{
+			name:                   "missing_listener_config",
+			errRespFn:              testErrResponseFn,
+			wantFactoryErr:         true,
+			wantFactoryErrContains: "missing listener config: invalid parameter",
+		},
+		{
+			name: "missing_err_resp_fn_config",
+			listenerCfg: func() *ListenerConfig {
+				listenerConfig := cfgListener(goodAddr)
+				listenerConfig.XForwardedForRejectNotPresent = true
+				return listenerConfig
+			}(),
+			wantFactoryErr:         true,
+			wantFactoryErrContains: "missing response error function: invalid parameter",
+		},
+		{
+			name: "missing_handler",
+			listenerCfg: func() *ListenerConfig {
+				listenerConfig := cfgListener(goodAddr)
+				listenerConfig.XForwardedForRejectNotPresent = true
+				return listenerConfig
+			}(),
+			useNilHandler:          true,
+			errRespFn:              testErrResponseFn,
+			wantFactoryErr:         true,
+			wantFactoryErrContains: "missing http handler: invalid parameter",
+		},
+		{
+			name: "reject_not_present_with_missing",
+			listenerCfg: func() *ListenerConfig {
+				listenerConfig := cfgListener(goodAddr)
+				listenerConfig.XForwardedForRejectNotPresent = true
+				return listenerConfig
+			}(),
+			errRespFn:        testErrResponseFn,
+			wantStatusCode:   400,
+			wantErr:          false,
+			wantBodyContains: "missing x-forwarded-for",
+		},
+		{
+			name: "reject_not_present_with_found",
+			listenerCfg: func() *ListenerConfig {
+				listenerConfig := cfgListener(goodAddr)
+				listenerConfig.XForwardedForRejectNotPresent = true
+				return listenerConfig
+			}(),
+			errRespFn:        testErrResponseFn,
+			xForwardedFor:    []string{"1.2.3.4"},
+			wantStatusCode:   200,
+			wantErr:          false,
+			wantBodyContains: "1.2.3.4:",
+		},
+		{
+			name: "allow_unauth",
+			listenerCfg: func() *ListenerConfig {
+				listenerConfig := cfgListener(badAddr)
+				listenerConfig.XForwardedForRejectNotPresent = true
+				return listenerConfig
+			}(),
+			errRespFn:        testErrResponseFn,
+			xForwardedFor:    []string{"5.6.7.8"},
+			wantStatusCode:   200,
+			wantErr:          false,
+			wantBodyContains: "127.0.0.1:",
+		},
+		{
+			name: "fail_unauth",
+			listenerCfg: func() *ListenerConfig {
+				listenerConfig := cfgListener(badAddr)
+				listenerConfig.XForwardedForRejectNotPresent = true
+				listenerConfig.XForwardedForRejectNotAuthorized = true
+				return listenerConfig
+			}(),
+			errRespFn:        testErrResponseFn,
+			xForwardedFor:    []string{"5.6.7.8"},
+			wantStatusCode:   400,
+			wantErr:          false,
+			wantBodyContains: "not authorized for x-forwarded-for",
+		},
+		{
+			name: "too_many_hops",
+			listenerCfg: func() *ListenerConfig {
+				listenerConfig := cfgListener(goodAddr)
+				listenerConfig.XForwardedForRejectNotPresent = true
+				listenerConfig.XForwardedForRejectNotAuthorized = true
+				listenerConfig.XForwardedForHopSkips = 4
+				return listenerConfig
+			}(),
+			errRespFn:        testErrResponseFn,
+			xForwardedFor:    []string{"2.3.4.5,3.4.5.6"},
+			wantStatusCode:   400,
+			wantErr:          false,
+			wantBodyContains: "would skip before earliest",
+		},
+		{
+			name: "correct_hop_skipping",
+			listenerCfg: func() *ListenerConfig {
+				listenerConfig := cfgListener(goodAddr)
+				listenerConfig.XForwardedForRejectNotPresent = true
+				listenerConfig.XForwardedForRejectNotAuthorized = true
+				listenerConfig.XForwardedForHopSkips = 1
+				return listenerConfig
+			}(),
+			errRespFn:        testErrResponseFn,
+			xForwardedFor:    []string{"2.3.4.5,3.4.5.6,4.5.6.7,5.6.7.8"},
+			wantStatusCode:   200,
+			wantErr:          false,
+			wantBodyContains: "4.5.6.7:",
+		},
+		{
+			name: "correct_hop_skipping_multi_header",
+			listenerCfg: func() *ListenerConfig {
+				listenerConfig := cfgListener(goodAddr)
+				listenerConfig.XForwardedForRejectNotPresent = true
+				listenerConfig.XForwardedForRejectNotAuthorized = true
+				listenerConfig.XForwardedForHopSkips = 1
+				return listenerConfig
+			}(),
+			errRespFn:        testErrResponseFn,
+			xForwardedFor:    []string{"2.3.4.5", "3.4.5.6,4.5.6.7", "5.6.7.8"},
+			wantStatusCode:   200,
+			wantErr:          false,
+			wantBodyContains: "4.5.6.7:",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			listener, err := net.Listen("tcp", "127.0.0.1:0")
+			require.NoError(err)
+			t.Cleanup(func() {
+				_ = listener.Close()
+			})
+			testHandler, err := func() (http.Handler, error) {
+				if tt.useNilHandler {
+					return WrapForwardedForHandler(nil, tt.listenerCfg, tt.errRespFn)
+				}
+				h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte(r.RemoteAddr))
+				})
+				return WrapForwardedForHandler(h, tt.listenerCfg, tt.errRespFn)
+			}()
+			if tt.wantFactoryErr {
+				require.Error(err)
+				if tt.wantFactoryErrContains != "" {
+					assert.Containsf(err.Error(), tt.wantFactoryErrContains, "missing %s from err: %s", tt.wantFactoryErrContains, err.Error())
+				}
+				return
+			}
+			server := &http.Server{
+				Handler: testHandler,
+			}
+			go func() {
+				if err := server.Serve(listener); err != nil {
+					if err != http.ErrServerClosed {
+						require.NoError(err)
+					}
+				}
+			}()
+			t.Cleanup(func() {
+				_ = server.Shutdown(context.Background())
+			})
+
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s/", listener.Addr().String()), nil)
+			require.NoError(err)
+			for _, h := range tt.xForwardedFor {
+				req.Header.Add("x-forwarded-for", h)
+			}
+			resp, err := http.DefaultClient.Do(req)
+			if tt.wantErr {
+				return
+			}
+			require.NoError(err)
+			require.Equalf(tt.wantStatusCode, resp.StatusCode, "expected error with %s status code and got: ", resp.StatusCode)
+			require.NotNil(resp.Body)
+			defer resp.Body.Close()
+			var buf bytes.Buffer
+			_, err = buf.ReadFrom(resp.Body)
+			require.NoError(err)
+			require.Containsf(buf.String(), tt.wantBodyContains, "bad error message: %v", err)
+		})
+	}
+}
+
+func Test_TrustedFromXForwardedFor(t *testing.T) {
+	goodAddr, err := sockaddr.NewIPAddr("127.0.0.1")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name            string
+		useNilReq       bool
+		listenerCfg     *ListenerConfig
+		xForwardedFor   []string
+		remoteAddr      string
+		wantAddr        *Addr
+		wantErr         bool
+		wantErrContains string
+	}{
+		{
+			name: "missing-req",
+			listenerCfg: func() *ListenerConfig {
+				listenerConfig := cfgListener(goodAddr)
+				listenerConfig.XForwardedForRejectNotPresent = true
+				return listenerConfig
+			}(),
+			useNilReq:       true,
+			wantErr:         true,
+			wantErrContains: "missing http request: invalid parameter",
+		},
+		{
+			name:            "missing-listener-cfg",
+			wantErr:         true,
+			wantErrContains: "missing listener config: invalid parameter",
+		},
+		{
+			name: "accept-not-present-with-missing",
+			listenerCfg: func() *ListenerConfig {
+				listenerConfig := cfgListener(goodAddr)
+				listenerConfig.XForwardedForRejectNotPresent = false
+				return listenerConfig
+			}(),
+			wantErr: false,
+		},
+		{
+			name: "accept-with-remote-addr-no-port",
+			listenerCfg: func() *ListenerConfig {
+				listenerConfig := cfgListener(goodAddr)
+				listenerConfig.XForwardedForRejectNotPresent = false
+				return listenerConfig
+			}(),
+			xForwardedFor: []string{"127.0.0.1"},
+			remoteAddr:    "localhost",
+			wantErr:       false,
+		},
+		{
+			name: "reject-with-remote-addr-no-port",
+			listenerCfg: func() *ListenerConfig {
+				listenerConfig := cfgListener(goodAddr)
+				listenerConfig.XForwardedForRejectNotPresent = true
+				return listenerConfig
+			}(),
+			xForwardedFor:   []string{"127.0.0.1"},
+			remoteAddr:      "localhost",
+			wantErr:         true,
+			wantErrContains: "error parsing client hostport",
+		},
+		{
+			name: "accept-with-invalid-remote-addr",
+			listenerCfg: func() *ListenerConfig {
+				listenerConfig := cfgListener(goodAddr)
+				listenerConfig.XForwardedForRejectNotPresent = false
+				return listenerConfig
+			}(),
+			xForwardedFor: []string{"127.0.0.1"},
+			remoteAddr:    "1.:22",
+			wantErr:       false,
+		},
+		{
+			name: "reject-with-invalid-remote-addr",
+			listenerCfg: func() *ListenerConfig {
+				listenerConfig := cfgListener(goodAddr)
+				listenerConfig.XForwardedForRejectNotPresent = true
+				return listenerConfig
+			}(),
+			xForwardedFor:   []string{"127.0.0.1"},
+			remoteAddr:      "1.:22",
+			wantErr:         true,
+			wantErrContains: "error parsing client address: invalid IPAddr",
+		},
+		{
+			name: "accept-with-invalid-x-forwaredfor-ip",
+			listenerCfg: func() *ListenerConfig {
+				listenerConfig := cfgListener(goodAddr)
+				listenerConfig.XForwardedForRejectNotPresent = false
+				return listenerConfig
+			}(),
+			xForwardedFor: []string{"1.:22"},
+			remoteAddr:    "127.0.0.1:22",
+			wantErr:       false,
+		},
+		{
+			name: "reject-with-invalid-x-forwaredfor-ip",
+			listenerCfg: func() *ListenerConfig {
+				listenerConfig := cfgListener(goodAddr)
+				listenerConfig.XForwardedForRejectNotPresent = true
+				return listenerConfig
+			}(),
+			xForwardedFor:   []string{"1.:22"},
+			remoteAddr:      "127.0.0.1:22",
+			wantErr:         true,
+			wantErrContains: "error parsing client address",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			listener, err := net.Listen("tcp", "127.0.0.1:0")
+			require.NoError(err)
+			t.Cleanup(func() {
+				_ = listener.Close()
+			})
+			var req *http.Request
+			if !tt.useNilReq {
+				req, err = http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s/", listener.Addr().String()), nil)
+				require.NoError(err)
+				for _, h := range tt.xForwardedFor {
+					req.Header.Add("x-forwarded-for", h)
+				}
+				if tt.remoteAddr != "" {
+					req.RemoteAddr = tt.remoteAddr
+				}
+			}
+			gotAddr, err := TrustedFromXForwardedFor(req, tt.listenerCfg)
+			if tt.wantErr {
+				require.Error(err)
+				if tt.wantErrContains != "" {
+					assert.Containsf(err.Error(), tt.wantErrContains, "missing %s from err: %s", tt.wantErrContains, err.Error())
+				}
+				return
+			}
+			require.NoError(err)
+			if tt.wantAddr != nil {
+				require.NotNil(gotAddr)
+				assert.Equal(tt.wantAddr, gotAddr)
+			} else {
+				assert.Nil(gotAddr)
+			}
+		})
+	}
+}
+
+func cfgListener(addr sockaddr.IPAddr) *ListenerConfig {
+	return &ListenerConfig{
+		XForwardedForAuthorizedAddrs: []*sockaddr.SockAddrMarshaler{
+			{
+				SockAddr: addr,
+			},
+		},
+	}
+}
+
+func Test_OrigRemoteAddrFromCtx(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name           string
+		ctx            context.Context
+		wantRemoteAddr string
+		wantNotOk      bool
+	}{
+		{
+			name:      "missing-ctx",
+			wantNotOk: true,
+		},
+		{
+			name:      "missing-remote-addr",
+			ctx:       context.Background(),
+			wantNotOk: true,
+		},
+		{
+			name: "valid",
+			ctx: func() context.Context {
+				ctx, err := newOrigRemoteAddrCtx(context.Background(), "host:port")
+				require.NoError(t, err)
+				return ctx
+			}(),
+			wantRemoteAddr: "host:port",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			got, ok := OrigRemoteAddrFromCtx(tt.ctx)
+			if tt.wantNotOk {
+				require.Falsef(ok, "should not have returned ok for the remote addr")
+				assert.Emptyf(got, "should not have returned %q remote addr", got)
+				return
+			}
+			require.Truef(ok, "should have been okay for getting a remote addr")
+			require.NotEmpty(got, "remote addr should not be empty")
+			assert.Equal(tt.wantRemoteAddr, got)
+		})
+	}
+
+	factoryTests := []struct {
+		name       string
+		ctx        context.Context
+		remoteAddr string
+		wantErr    bool
+	}{
+		{"context", nil, "host:port", true},
+		{"remote", context.Background(), "", true},
+		{"valid", context.Background(), "host:port", false},
+	}
+	for _, tt := range factoryTests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			ctx, err := newOrigRemoteAddrCtx(tt.ctx, tt.remoteAddr)
+			if tt.wantErr {
+				require.Error(err)
+				assert.Nil(ctx)
+				assert.ErrorIs(err, ErrInvalidParameter)
+				return
+			}
+			require.NoError(err)
+			assert.NotNil(ctx)
+			got, found := OrigRemoteAddrFromCtx(ctx)
+			assert.True(found)
+			assert.Equal(tt.remoteAddr, got)
+		})
+	}
+
+}

--- a/listenerutil/forwarded_for_test.go
+++ b/listenerutil/forwarded_for_test.go
@@ -344,6 +344,40 @@ func Test_TrustedFromXForwardedFor(t *testing.T) {
 			wantErr:         true,
 			wantErrContains: "error parsing client address",
 		},
+		{
+			name: "accept-with-x-forwaredfor-including-port",
+			listenerCfg: func() *ListenerConfig {
+				listenerConfig := cfgListener(goodAddr)
+				listenerConfig.XForwardedForRejectNotPresent = false
+				return listenerConfig
+			}(),
+			xForwardedFor: []string{"127.0.0.1:127"},
+			remoteAddr:    "127.0.0.1:22",
+			wantAddr:      &Addr{Host: "127.0.0.1", Port: "22"},
+			wantErr:       false,
+		},
+		{
+			name: "accept-with-x-forwaredfor-including-port-and-too-many-colons",
+			listenerCfg: func() *ListenerConfig {
+				listenerConfig := cfgListener(goodAddr)
+				listenerConfig.XForwardedForRejectNotPresent = false
+				return listenerConfig
+			}(),
+			xForwardedFor: []string{"127.0.0.1::::127"},
+			remoteAddr:    "127.0.0.1:22",
+			wantErr:       false,
+		},
+		{
+			name: "reject-with-x-forwaredfor-including-port-and-too-many-colons",
+			listenerCfg: func() *ListenerConfig {
+				listenerConfig := cfgListener(goodAddr)
+				listenerConfig.XForwardedForRejectNotPresent = true
+				return listenerConfig
+			}(),
+			xForwardedFor: []string{"127.0.0.1::::127"},
+			remoteAddr:    "127.0.0.1:22",
+			wantErr:       true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/listenerutil/go.mod
+++ b/listenerutil/go.mod
@@ -15,5 +15,6 @@ require (
 	github.com/jefferai/isbadcipher v0.0.0-20190226160619-51d2077c035f
 	github.com/mattn/go-colorable v0.1.6 // indirect
 	github.com/mitchellh/cli v1.1.2
+	github.com/stretchr/testify v1.7.0
 	golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980 // indirect
 )

--- a/listenerutil/go.sum
+++ b/listenerutil/go.sum
@@ -79,6 +79,7 @@ golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980 h1:OjiUf46hAmXblsZdnoSXsEUSKU8r1UEzcL5RVZ4gO9Y=
 golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
- `TrustedFromXForwardedFor` uses the XForwardedFor* listener cfg setting to determine how/if headers are trusted/allowed for inbound http requests
- `WrapForwardedForHandler` which is an http middleware wrapper that uses `TrustedFromXForwardedFor` to determine how/if headers are trusted/allowed for inbound http requests