### PR TITLE
feat(configutil): Add env and file support to ClusterName

### DIFF
--- a/configutil/config.go
+++ b/configutil/config.go
@@ -1,6 +1,7 @@
 package configutil
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"time"
@@ -95,6 +96,11 @@ func ParseConfig(d string) (*SharedConfig, error) {
 			return nil, err
 		}
 		result.DisableMlockRaw = nil
+	}
+
+	result.ClusterName, err = parseutil.ParsePath(result.ClusterName)
+	if err != nil && !errors.Is(err, parseutil.ErrNotAUrl) {
+		return nil, fmt.Errorf("error parsing cluster name: %w", err)
 	}
 
 	list, ok := obj.Node.(*ast.ObjectList)

--- a/configutil/config_test.go
+++ b/configutil/config_test.go
@@ -1,0 +1,71 @@
+package configutil
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseConfig(t *testing.T) {
+	tests := []struct {
+		name            string
+		in              string
+		stateFn         func(t *testing.T)
+		expSharedConfig *SharedConfig
+		expErr          bool
+		expErrIs        error
+		expErrStr       string
+	}{
+		{
+			name:            "cluster name set directly",
+			in:              `cluster_name = "test-cluster"`,
+			expSharedConfig: &SharedConfig{ClusterName: "test-cluster"},
+			expErr:          false,
+		},
+		{
+			name: "cluster name set to environment variable",
+			in:   `cluster_name = "env://SHARED_CFG_CLUSTER_NAME"`,
+			stateFn: func(t *testing.T) {
+				t.Setenv("SHARED_CFG_CLUSTER_NAME", "test-cluster")
+			},
+			expSharedConfig: &SharedConfig{ClusterName: "test-cluster"},
+			expErr:          false,
+		},
+		{
+			name:            "cluster name set to something that isn't a URL",
+			in:              `cluster_name = "test\x00cluster"`,
+			expSharedConfig: &SharedConfig{ClusterName: "test\x00cluster"},
+			expErr:          false,
+		},
+		{
+			name:            "cluster name ParsePath fail (missing file)",
+			in:              `cluster_name = "file://doesnt_exist_ck3iop2w"`,
+			expSharedConfig: nil,
+			expErr:          true,
+			expErrIs:        os.ErrNotExist,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.stateFn != nil {
+				tt.stateFn(t)
+			}
+
+			sc, err := ParseConfig(tt.in)
+			if tt.expErr {
+				if tt.expErrIs != nil {
+					require.ErrorIs(t, err, tt.expErrIs)
+				} else {
+					require.EqualError(t, err, tt.expErrStr)
+				}
+				require.Nil(t, sc)
+				return
+			}
+
+			require.NoError(t, err)
+			require.EqualValues(t, tt.expSharedConfig, sc)
+		})
+	}
+}


### PR DESCRIPTION
A user is now able to set cluster_name in their HCL to point to an environment variable (env://) or file (file://) and the logic will dynamically resolve the value within and assign it to the field.