### PR TITLE
feat(parseutil) Support parsing slices of ints

### DIFF
--- a/parseutil/parseutil.go
+++ b/parseutil/parseutil.go
@@ -232,6 +232,94 @@ func ParseInt(in interface{}) (int64, error) {
 	return ret, nil
 }
 
+func ParseDirectIntSlice(in interface{}) ([]int64, error) {
+	var ret []int64
+
+	switch in.(type) {
+	case []int:
+		for _, v := range in.([]int) {
+			ret = append(ret, int64(v))
+		}
+	case []int32:
+		for _, v := range in.([]int32) {
+			ret = append(ret, int64(v))
+		}
+	case []int64:
+		// For consistency to ensure callers can always modify ret without
+		// impacting in.
+		for _, v := range in.([]int64) {
+			ret = append(ret, v)
+		}
+	case []uint:
+		for _, v := range in.([]uint) {
+			ret = append(ret, int64(v))
+		}
+	case []uint32:
+		for _, v := range in.([]uint32) {
+			ret = append(ret, int64(v))
+		}
+	case []uint64:
+		for _, v := range in.([]uint64) {
+			ret = append(ret, int64(v))
+		}
+	case []json.Number:
+		for _, v := range in.([]json.Number) {
+			element, err := ParseInt(v)
+			if err != nil {
+				return nil, err
+			}
+			ret = append(ret, element)
+		}
+	case []string:
+		for _, v := range in.([]string) {
+			element, err := ParseInt(v)
+			if err != nil {
+				return nil, err
+			}
+			ret = append(ret, element)
+		}
+	default:
+		return nil, errors.New("could not parse value from input")
+	}
+
+	return ret, nil
+}
+
+// ParseIntSlice is a helper function for handling upgrades of optional
+// slices; that is, if the API accepts a type similar to <int|[]int>,
+// nicely handle the common cases of providing only an int-ish, providing
+// an actual slice of int-ishes, or providing a comma-separated list of
+// numbers.
+func ParseIntSlice(in interface{}) ([]int64, error) {
+	if ret, err := ParseInt(in); err == nil {
+		return []int64{ret}, nil
+	}
+
+	if ret, err := ParseDirectIntSlice(in); err == nil {
+		return ret, nil
+	}
+
+	if strings, err := ParseCommaStringSlice(in); err == nil {
+		var ret []int64
+		for _, v := range strings {
+			if v == "" {
+				// Ignore empty fields
+				continue
+			}
+
+			element, err := ParseInt(v)
+			if err != nil {
+				return nil, err
+			}
+			ret = append(ret, element)
+		}
+
+		return ret, nil
+	}
+
+	return nil, errors.New("could not parse value from input")
+}
+
 func ParseBool(in interface{}) (bool, error) {
 	var result bool
 	if err := mapstructure.WeakDecode(in, &result); err != nil {

--- a/parseutil/parseutil_test.go
+++ b/parseutil/parseutil_test.go
@@ -333,3 +333,157 @@ func Test_ParseBool(t *testing.T) {
 		t.Fatal("wrong output")
 	}
 }
+
+func equalInt64Slice(a, b []int64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func Test_ParseIntSlice(t *testing.T) {
+	// Handles testing of ParseInt, ParseDirectIntSlice, and ParseIntSlice.
+	testCases := []struct {
+		inp      interface{}
+		valid    bool
+		expected []int64
+	}{
+		// ParseInt
+		{
+			int(-1),
+			true,
+			[]int64{-1},
+		},
+		{
+			int32(-1),
+			true,
+			[]int64{-1},
+		},
+		{
+			int64(-1),
+			true,
+			[]int64{-1},
+		},
+		{
+			uint(1),
+			true,
+			[]int64{1},
+		},
+		{
+			uint32(1),
+			true,
+			[]int64{1},
+		},
+		{
+			uint64(1),
+			true,
+			[]int64{1},
+		},
+		{
+			json.Number("1"),
+			true,
+			[]int64{1},
+		},
+		{
+			"1",
+			true,
+			[]int64{1},
+		},
+		// ParseDirectIntSlice
+		{
+			[]int{1, -2, 3},
+			true,
+			[]int64{1, -2, 3},
+		},
+		{
+			[]int32{1, -2, 3},
+			true,
+			[]int64{1, -2, 3},
+		},
+		{
+			[]int64{1, -2, 3},
+			true,
+			[]int64{1, -2, 3},
+		},
+		{
+			[]uint{1, 2, 3},
+			true,
+			[]int64{1, 2, 3},
+		},
+		{
+			[]uint32{1, 2, 3},
+			true,
+			[]int64{1, 2, 3},
+		},
+		{
+			[]uint64{1, 2, 3},
+			true,
+			[]int64{1, 2, 3},
+		},
+		{
+			[]json.Number{json.Number("1"), json.Number("2"), json.Number("3")},
+			true,
+			[]int64{1, 2, 3},
+		},
+		{
+			[]string{"1", "2", "3"},
+			true,
+			[]int64{1, 2, 3},
+		},
+		// Comma separated list
+		{
+			"1",
+			true,
+			[]int64{1},
+		},
+		{
+			"1,",
+			true,
+			[]int64{1},
+		},
+		{
+			",1",
+			true,
+			[]int64{1},
+		},
+		{
+			",1,",
+			true,
+			[]int64{1},
+		},
+		{
+			"1,2",
+			true,
+			[]int64{1,2},
+		},
+		{
+			"1,2,3",
+			true,
+			[]int64{1,2,3},
+		},
+	}
+
+	for _, tc := range testCases {
+		outp, err := ParseIntSlice(tc.inp)
+		if err != nil {
+			if tc.valid {
+				t.Errorf("failed to parse: %v", tc.inp)
+			}
+			continue
+		}
+		if err == nil && !tc.valid {
+			t.Errorf("no error for: %v", tc.inp)
+			continue
+		}
+		if !equalInt64Slice(outp, tc.expected) {
+			t.Errorf("input %v parsed as %v, expected %v", tc.inp, outp, tc.expected)
+		}
+	}
+}


### PR DESCRIPTION
The Vault SSH secrets engine presently supports specifying allowed key
sizes in a field of type `map[string]int`. The notable limitation of this
type is that it cannot handle algorithms for which multiple key lengths
are allowed, e.g., allowing both 2048 and 4096-bit RSA keys. It relies
on `parseutil` to handle this conversion (for each element of the map,
calling `ParseInt(...)`).

A better type is `map[string][]int`; this allows explicitly specifying
multiple allowed key lengths and giving flexibility to the operator over
whether or not to restrict uncommon or intermediate key sizes (e.g.,
prohibiting 3072-bit RSA keys if certain deployed implementations are
not compatible -- though this is unlikely in practice).

While the SSH module can maintain this parsing logic, it'd be nice to
include it in `parseutil` instead. Here, we wish to remain backwards
compatible and relatively flexible in what we accept; elsewhere in the
API we use comma-separated lists of strings (e.g., allowed_domains in
the PKI secrets engine), so it makes sense to do the same here, in
addition to slices of `int`-like types or just a bare single `int`-ish.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

---

Related PR: https://github.com/hashicorp/vault/pull/13991 