### PR TITLE
Handle JSON Number in ParseCommaStringSlice

### DIFF
--- a/parseutil/parseutil.go
+++ b/parseutil/parseutil.go
@@ -338,6 +338,10 @@ func ParseString(in interface{}) (string, error) {
 
 func ParseCommaStringSlice(in interface{}) ([]string, error) {
 	rawString, ok := in.(string)
+	if !ok {
+		return nil, fmt.Errorf("error parsing %v as string", rawString)
+	}
+
 	if ok && rawString == "" {
 		return []string{}, nil
 	}

--- a/parseutil/parseutil.go
+++ b/parseutil/parseutil.go
@@ -337,10 +337,12 @@ func ParseString(in interface{}) (string, error) {
 }
 
 func ParseCommaStringSlice(in interface{}) ([]string, error) {
-	rawString, ok := in.(string)
-	if !ok {
-		return nil, fmt.Errorf("error parsing %v as string", rawString)
+	jsonIn, ok := in.(json.Number)
+	if ok {
+		in = jsonIn.String()
 	}
+
+	rawString, ok := in.(string)
 
 	if ok && rawString == "" {
 		return []string{}, nil

--- a/parseutil/parseutil.go
+++ b/parseutil/parseutil.go
@@ -343,7 +343,6 @@ func ParseCommaStringSlice(in interface{}) ([]string, error) {
 	}
 
 	rawString, ok := in.(string)
-
 	if ok && rawString == "" {
 		return []string{}, nil
 	}

--- a/parseutil/parseutil_test.go
+++ b/parseutil/parseutil_test.go
@@ -2,6 +2,7 @@ package parseutil
 
 import (
 	"encoding/json"
+	"math/cmplx"
 	"testing"
 	"time"
 )
@@ -461,12 +462,12 @@ func Test_ParseIntSlice(t *testing.T) {
 		{
 			"1,2",
 			true,
-			[]int64{1,2},
+			[]int64{1, 2},
 		},
 		{
 			"1,2,3",
 			true,
-			[]int64{1,2,3},
+			[]int64{1, 2, 3},
 		},
 	}
 
@@ -503,12 +504,18 @@ func equalStringSlice(a, b []string) bool {
 }
 
 func Test_ParseCommaStringSlice(t *testing.T) {
-	cases := []struct{
+	cases := []struct {
 		name     string
-		inp       interface{}
+		inp      interface{}
 		expected []string
 		valid    bool
 	}{
+		{
+			"nil",
+			nil,
+			[]string{},
+			true,
+		},
 		{
 			"empty string",
 			"",
@@ -516,19 +523,19 @@ func Test_ParseCommaStringSlice(t *testing.T) {
 			true,
 		},
 		{
-			"single value",
+			"string without commas",
 			"foo",
 			[]string{"foo"},
 			true,
 		},
 		{
-			"multiple values",
+			"comma-separated string",
 			"foo,bar,baz",
 			[]string{"foo", "bar", "baz"},
 			true,
 		},
 		{
-			"multiple values with trim",
+			"comma-separated string with trim",
 			"  foo ,    bar   ,baz  ",
 			[]string{"foo", "bar", "baz"},
 			true,
@@ -536,12 +543,90 @@ func Test_ParseCommaStringSlice(t *testing.T) {
 		{
 			"json number",
 			json.Number("123"),
+			[]string{"123"},
+			true,
+		},
+		{
+			"int",
+			1,
+			[]string{"1"},
+			true,
+		},
+		{
+			"float",
+			5.5,
+			[]string{"5.5"},
+			true,
+		},
+		{
+			"rune",
+			'a',
+			[]string{"97"},
+			true,
+		},
+		{
+			"bool",
+			true,
+			[]string{"1"},
+			true,
+		},
+		{
+			"complex",
+			cmplx.Sqrt(-1),
 			nil,
 			false,
 		},
 		{
 			"string slice",
 			[]string{"foo", "bar", "baz"},
+			[]string{"foo", "bar", "baz"},
+			true,
+		},
+		{
+			"json number slice",
+			[]json.Number{json.Number("1"), json.Number("2")},
+			[]string{"1", "2"},
+			true,
+		},
+		{
+			"int slice",
+			[]int{1, 2, 3},
+			[]string{"1", "2", "3"},
+			true,
+		},
+		{
+			"float slice",
+			[]float64{1.1, 1.2, 1.3},
+			[]string{"1.1", "1.2", "1.3"},
+			true,
+		},
+		{
+			"rune slice",
+			[]rune{'a', 'b', 'c'},
+			[]string{"97", "98", "99"},
+			true,
+		},
+		{
+			"bool slice",
+			[]bool{true, false, true},
+			[]string{"1", "0", "1"},
+			true,
+		},
+		{
+			"complex slice",
+			[]complex128{cmplx.Sqrt(-1)},
+			nil,
+			false,
+		},
+		{
+			"map",
+			map[string]interface{}{"foo": "bar"},
+			nil,
+			false,
+		},
+		{
+			"struct",
+			struct{ name string }{"foo"},
 			nil,
 			false,
 		},
@@ -565,7 +650,6 @@ func Test_ParseCommaStringSlice(t *testing.T) {
 			if !equalStringSlice(outp, tc.expected) {
 				t.Errorf("input %v parsed as %v, expected %v", tc.inp, outp, tc.expected)
 			}
-
 		})
 	}
 }

--- a/parseutil/parseutil_test.go
+++ b/parseutil/parseutil_test.go
@@ -487,3 +487,85 @@ func Test_ParseIntSlice(t *testing.T) {
 		}
 	}
 }
+
+func equalStringSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func Test_ParseCommaStringSlice(t *testing.T) {
+	cases := []struct{
+		name     string
+		inp       interface{}
+		expected []string
+		valid    bool
+	}{
+		{
+			"empty string",
+			"",
+			[]string{},
+			true,
+		},
+		{
+			"single value",
+			"foo",
+			[]string{"foo"},
+			true,
+		},
+		{
+			"multiple values",
+			"foo,bar,baz",
+			[]string{"foo", "bar", "baz"},
+			true,
+		},
+		{
+			"multiple values with trim",
+			"  foo ,    bar   ,baz  ",
+			[]string{"foo", "bar", "baz"},
+			true,
+		},
+		{
+			"json number",
+			json.Number("123"),
+			nil,
+			false,
+		},
+		{
+			"string slice",
+			[]string{"foo", "bar", "baz"},
+			nil,
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			outp, err := ParseCommaStringSlice(tc.inp)
+			if tc.valid && err != nil {
+				t.Errorf("failed to parse: %v. err: %v", tc.inp, err)
+			}
+
+			if !tc.valid && err == nil {
+				t.Errorf("no error for: %v", tc.inp)
+			}
+
+			if !equalStringSlice(outp, tc.expected) {
+				t.Errorf("input %v parsed as %v, expected %v", tc.inp, outp, tc.expected)
+			}
+
+		})
+	}
+}

--- a/parseutil/parseutil_test.go
+++ b/parseutil/parseutil_test.go
@@ -571,8 +571,20 @@ func Test_ParseCommaStringSlice(t *testing.T) {
 			true,
 		},
 		{
+			"byte",
+			byte(10),
+			[]string{"10"},
+			true,
+		},
+		{
 			"complex",
 			cmplx.Sqrt(-1),
+			nil,
+			false,
+		},
+		{
+			"time",
+			time.Now(),
 			nil,
 			false,
 		},


### PR DESCRIPTION
The `ParseCommaStringSlice` function in `parseutil` performs a type assertion (i.e. `in.(string)`) but does not return an error if the assertion fails. Without an early return, a panic might occur in the `mapstructure.NewDecoder` call. `StringToSliceHookFunc` in `mapstructure` returns a hook func that performs a similar string type assertion but [does not verify that it was successful](https://github.com/mitchellh/mapstructure/blob/1b7c3d8e219d00abb1d9267545c50c6c12fee562/decode_hooks.go#L91). This can occur if the input is a `json.Number` given that its `reflect.Kind` is `string`. The type assertion in `mapstructure` will panic with `invalid type assertion: data.(string) (non-interface type json.Number on left)`.

Unit tests for `ParseCommaStringSlice` were also added as there weren't any prior to this PR.