### PR TITLE
fix kv builder out of bounds panic on single backslash

### DIFF
--- a/kv-builder/builder.go
+++ b/kv-builder/builder.go
@@ -91,7 +91,7 @@ func (b *Builder) add(raw string) error {
 			}
 
 			value = string(contents)
-		} else if value[0] == '\\' && value[1] == '@' {
+		} else if len(value) >= 2 && value[0] == '\\' && value[1] == '@' {
 			value = value[1:]
 		} else if value == "-" {
 			if b.Stdin == nil {

--- a/kv-builder/builder_test.go
+++ b/kv-builder/builder_test.go
@@ -41,6 +41,23 @@ func TestBuilder_escapedAt(t *testing.T) {
 	}
 }
 
+func TestBuilder_singleBackslash(t *testing.T) {
+	var b Builder
+	err := b.Add("foo=bar", "bar=\\")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	expected := map[string]interface{}{
+		"foo": "bar",
+		"bar": "\\",
+	}
+	actual := b.Map()
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("bad: %#v", actual)
+	}
+}
+
 func TestBuilder_stdin(t *testing.T) {
 	var b Builder
 	b.Stdin = bytes.NewBufferString("baz")


### PR DESCRIPTION
The KV Builder panics when attempting to process a single backslash. The KV Builder `add` method currently assumes that the provided string has at least two characters when attempting to check for an escaped `@` (i.e. `\@`). The proposed fix is to guard with a length check.

In additional to the added unit test, this change was functionally tested with the Vault kv secret engine CLI.

Before change:

```
❯ vault kv put secret/foo 'bar=\'
panic: runtime error: index out of range [1] with length 1

goroutine 1 [running]:
github.com/hashicorp/go-secure-stdlib/kv-builder.(*Builder).add(0xc0008cb440, {0x7ffeefbff898, 0x11880ee8})
        /Users/ccapurso/go/pkg/mod/github.com/hashicorp/go-secure-stdlib/kv-builder@v0.1.1/builder.go:94 +0x832
github.com/hashicorp/go-secure-stdlib/kv-builder.(*Builder).Add(0x7ffeefbff88d, {0xc0001a6040, 0x1, 0x484dde5})
        /Users/ccapurso/go/pkg/mod/github.com/hashicorp/go-secure-stdlib/kv-builder@v0.1.1/builder.go:32 +0x89
github.com/hashicorp/vault/command.parseArgsData({0x6449e40, 0xc000194000}, {0xc0001a6040, 0x1, 0x1})
        /Users/ccapurso/git/vault/command/base_helpers.go:134 +0xaa
github.com/hashicorp/vault/command.(*KVPutCommand).Run(0xc0008cab20, {0xc0001a6030, 0x2, 0x2})
        /Users/ccapurso/git/vault/command/kv_put.go:120 +0x171
github.com/mitchellh/cli.(*CLI).Run(0xc000145cc0)
        /Users/ccapurso/go/pkg/mod/github.com/mitchellh/cli@v1.1.2/cli.go:262 +0x5f8
github.com/hashicorp/vault/command.RunCustom({0xc0001a6010, 0x4, 0x4}, 0xc0000001a0)
        /Users/ccapurso/git/vault/command/main.go:180 +0x9f7
github.com/hashicorp/vault/command.Run(...)
        /Users/ccapurso/git/vault/command/main.go:88
main.main()
        /Users/ccapurso/git/vault/main.go:10 +0x52
```

After change:

```
❯ vault kv put secret/foo 'bar=\'
= Secret Path =
secret/data/foo

======= Metadata =======
Key                Value
---                -----
created_time       2022-03-15T14:38:07.024316Z
custom_metadata    <nil>
deletion_time      n/a
destroyed          false
version            1
```

```
❯ vault kv get secret/foo
= Secret Path =
secret/data/foo

======= Metadata =======
Key                Value
---                -----
created_time       2022-03-15T14:38:07.024316Z
custom_metadata    <nil>
deletion_time      n/a
destroyed          false
version            1

=== Data ===
Key    Value
---    -----
bar    \
```