### PR TITLE
Allow plugins to be specified as direct file paths

### DIFF
--- a/configutil/Makefile
+++ b/configutil/Makefile
@@ -1,0 +1,8 @@
+PLUGIN_TMP_DIR := $(shell mktemp -d)
+
+test-plugin:
+	go build -o "${PLUGIN_TMP_DIR}/aeadplugin" testplugins/aead/main.go
+	PLUGIN_PATH="${PLUGIN_TMP_DIR}/aeadplugin" go test -v -run TestFilePlugin
+
+
+.PHONY: test-plugin

--- a/configutil/file_plugin_test.go
+++ b/configutil/file_plugin_test.go
@@ -4,12 +4,12 @@ import (
 	context "context"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"os"
 	"testing"
 
 	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
 	"github.com/hashicorp/go-secure-stdlib/pluginutil/v2"
-	"github.com/kr/pretty"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/sha3"
@@ -36,51 +36,125 @@ func TestFilePlugin(t *testing.T) {
 	sha3384Bytes := sha3384Hash.Sum(nil)
 
 	testCases := []struct {
-		name            string
-		pluginChecksum  []byte
-		pluginHashType  pluginutil.HashType
-		wantErrContains string
+		name                  string                // name of the test
+		pluginChecksum        []byte                // checksum to use
+		pluginHashMethod      pluginutil.HashMethod // hash method to use
+		wantErrContains       string                // Error from the plugin process
+		hacheSeeEll           string                // If set, will be parsed and used to populate values
+		wantConfigErrContains string                // Error from any set config
 	}{
 		{
-			name:           "valid checksum",
-			pluginChecksum: sha2256Bytes[:],
-			pluginHashType: pluginutil.HashTypeSha2256,
+			name:             "valid checksum",
+			pluginChecksum:   sha2256Bytes[:],
+			pluginHashMethod: pluginutil.HashMethodSha2256,
 		},
 		{
-			name:            "invalid checksum",
-			pluginChecksum:  modifiedSha2[:],
-			pluginHashType:  pluginutil.HashTypeSha2256,
-			wantErrContains: "checksums did not match",
+			name:             "invalid checksum",
+			pluginChecksum:   modifiedSha2[:],
+			pluginHashMethod: pluginutil.HashMethodSha2256,
+			wantErrContains:  "checksums did not match",
 		},
 		{
-			name:           "valid checksum, other type",
-			pluginChecksum: sha3384Bytes[:],
-			pluginHashType: pluginutil.HashTypeSha3384,
+			name:             "valid checksum, other type",
+			pluginChecksum:   sha3384Bytes[:],
+			pluginHashMethod: pluginutil.HashMethodSha3384,
+		},
+		{
+			name: "invalid hcl no checksum",
+			hacheSeeEll: fmt.Sprintf(`
+				kms "aead" {
+					purpose = "root"
+					aead_type = "aes-gcm"
+					plugin_path = "%s"
+				}
+				`, pluginPath),
+			wantConfigErrContains: "plugin_path specified but plugin_checksum empty",
+		},
+		{
+			name: "invalid hcl no path",
+			hacheSeeEll: fmt.Sprintf(`
+				kms "aead" {
+					purpose = "root"
+					aead_type = "aes-gcm"
+					plugin_checksum = "%s"
+				}
+				`, hex.EncodeToString(sha2256Bytes[:])),
+			wantConfigErrContains: "plugin_checksum specified but plugin_path empty",
+		},
+		{
+			name: "invalid hcl unknown hash method",
+			hacheSeeEll: fmt.Sprintf(`
+				kms "aead" {
+					purpose = "root"
+					aead_type = "aes-gcm"
+					plugin_path = "%s"
+					plugin_checksum = "%s"
+					plugin_hash_method = "foobar"
+				}
+				`, pluginPath, hex.EncodeToString(sha2256Bytes[:])),
+			wantErrContains: "unsupported hash method",
+		},
+		{
+			name: "valid hcl",
+			hacheSeeEll: fmt.Sprintf(`
+				kms "aead" {
+					purpose = "root"
+					aead_type = "aes-gcm"
+					plugin_path = "%s"
+					plugin_checksum = "%s"
+				}
+				`, pluginPath, hex.EncodeToString(sha2256Bytes[:])),
+		},
+		{
+			name: "valid hcl alternate checksum",
+			hacheSeeEll: fmt.Sprintf(`
+			kms "aead" {
+				purpose = "root"
+				aead_type = "aes-gcm"
+				plugin_path = "%s"
+				plugin_checksum = "%s"
+				plugin_hash_method = "%s"
+			}
+			`, pluginPath, hex.EncodeToString(sha3384Bytes[:]), pluginutil.HashMethodSha3384),
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
-			wrapper, cleanup, err := configureWrapper(
-				ctx,
-				&KMS{
+			var kms *KMS
+			var pluginOpts []pluginutil.Option
+			switch tc.hacheSeeEll == "" {
+			case true:
+				kms = &KMS{
 					Type:    string(wrapping.WrapperTypeAead),
 					Purpose: []string{"foobar"},
-				},
+				}
+				pluginOpts = append(pluginOpts, pluginutil.WithPluginFile(
+					pluginutil.PluginFileInfo{
+						Name:       "aead",
+						Path:       pluginPath,
+						Checksum:   tc.pluginChecksum,
+						HashMethod: tc.pluginHashMethod,
+					}),
+				)
+			default:
+				conf, err := ParseConfig(tc.hacheSeeEll)
+				if tc.wantConfigErrContains != "" {
+					require.Error(err)
+					assert.Contains(err.Error(), tc.wantConfigErrContains)
+					return
+				}
+				require.NoError(err)
+				require.Len(conf.Seals, 1)
+				kms = conf.Seals[0]
+			}
+			wrapper, cleanup, err := configureWrapper(
+				ctx,
+				kms,
 				nil,
 				nil,
-				WithPluginOptions(
-					pluginutil.WithPluginFile(
-						pluginutil.PluginFileInfo{
-							Name:     "aead",
-							Path:     pluginPath,
-							Checksum: tc.pluginChecksum,
-							HashType: tc.pluginHashType,
-						},
-					),
-				),
+				WithPluginOptions(pluginOpts...),
 			)
-			t.Log(pretty.Sprint(hex.EncodeToString(tc.pluginChecksum)))
 			if tc.wantErrContains != "" {
 				require.Error(err)
 				assert.Contains(err.Error(), tc.wantErrContains)

--- a/configutil/file_plugin_test.go
+++ b/configutil/file_plugin_test.go
@@ -1,7 +1,7 @@
 package configutil
 
 import (
-	context "context"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"

--- a/configutil/file_plugin_test.go
+++ b/configutil/file_plugin_test.go
@@ -1,0 +1,94 @@
+package configutil
+
+import (
+	context "context"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"testing"
+
+	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
+	"github.com/hashicorp/go-secure-stdlib/pluginutil/v2"
+	"github.com/kr/pretty"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/sha3"
+)
+
+func TestFilePlugin(t *testing.T) {
+	ctx := context.Background()
+
+	pluginPath := os.Getenv("PLUGIN_PATH")
+	if pluginPath == "" {
+		t.Skipf("skipping plugin test as no PLUGIN_PATH specified")
+	}
+
+	pluginBytes, err := os.ReadFile(pluginPath)
+	require.NoError(t, err)
+
+	sha2256Bytes := sha256.Sum256(pluginBytes)
+	modifiedSha2 := sha256.Sum256(pluginBytes)
+	modifiedSha2[0] = '0'
+	modifiedSha2[1] = '0'
+	sha3384Hash := sha3.New384()
+	_, err = sha3384Hash.Write(pluginBytes)
+	require.NoError(t, err)
+	sha3384Bytes := sha3384Hash.Sum(nil)
+
+	testCases := []struct {
+		name            string
+		pluginChecksum  []byte
+		pluginHashType  pluginutil.HashType
+		wantErrContains string
+	}{
+		{
+			name:           "valid checksum",
+			pluginChecksum: sha2256Bytes[:],
+			pluginHashType: pluginutil.HashTypeSha2256,
+		},
+		{
+			name:            "invalid checksum",
+			pluginChecksum:  modifiedSha2[:],
+			pluginHashType:  pluginutil.HashTypeSha2256,
+			wantErrContains: "checksums did not match",
+		},
+		{
+			name:           "valid checksum, other type",
+			pluginChecksum: sha3384Bytes[:],
+			pluginHashType: pluginutil.HashTypeSha3384,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			wrapper, cleanup, err := configureWrapper(
+				ctx,
+				&KMS{
+					Type:    string(wrapping.WrapperTypeAead),
+					Purpose: []string{"foobar"},
+				},
+				nil,
+				nil,
+				WithPluginOptions(
+					pluginutil.WithPluginFile(
+						pluginutil.PluginFileInfo{
+							Name:     "aead",
+							Path:     pluginPath,
+							Checksum: tc.pluginChecksum,
+							HashType: tc.pluginHashType,
+						},
+					),
+				),
+			)
+			t.Log(pretty.Sprint(hex.EncodeToString(tc.pluginChecksum)))
+			if tc.wantErrContains != "" {
+				require.Error(err)
+				assert.Contains(err.Error(), tc.wantErrContains)
+				return
+			}
+			require.NoError(err)
+			assert.NotNil(wrapper)
+			assert.NoError(cleanup())
+		})
+	}
+}

--- a/configutil/go.mod
+++ b/configutil/go.mod
@@ -10,9 +10,11 @@ require (
 	github.com/hashicorp/go-plugin v1.4.3
 	github.com/hashicorp/go-secure-stdlib/listenerutil v0.1.4
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.2
-	github.com/hashicorp/go-secure-stdlib/pluginutil/v2 v2.0.0
+	github.com/hashicorp/go-secure-stdlib/pluginutil/v2 v2.0.1-0.20220317202442-3050f509c668
 	github.com/hashicorp/hcl v1.0.0
+	github.com/kr/pretty v0.3.0
 	github.com/stretchr/testify v1.7.0
+	golang.org/x/crypto v0.0.0-20220313003712-b769efc7c000
 	google.golang.org/protobuf v1.27.1
 )
 
@@ -36,6 +38,7 @@ require (
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/imdario/mergo v0.3.11 // indirect
 	github.com/jefferai/isbadcipher v0.0.0-20190226160619-51d2077c035f // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.6 // indirect
 	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/mitchellh/cli v1.1.2 // indirect
@@ -48,7 +51,6 @@ require (
 	github.com/posener/complete v1.1.1 // indirect
 	github.com/rogpeppe/go-internal v1.8.1 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
-	golang.org/x/crypto v0.0.0-20220313003712-b769efc7c000 // indirect
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
 	golang.org/x/sys v0.0.0-20220204135822-1c1b9b1eba6a // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/configutil/go.mod
+++ b/configutil/go.mod
@@ -10,9 +10,8 @@ require (
 	github.com/hashicorp/go-plugin v1.4.3
 	github.com/hashicorp/go-secure-stdlib/listenerutil v0.1.4
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.2
-	github.com/hashicorp/go-secure-stdlib/pluginutil/v2 v2.0.1-0.20220317202442-3050f509c668
+	github.com/hashicorp/go-secure-stdlib/pluginutil/v2 v2.0.1-0.20220318133345-4b0c6b19f281
 	github.com/hashicorp/hcl v1.0.0
-	github.com/kr/pretty v0.3.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/crypto v0.0.0-20220313003712-b769efc7c000
 	google.golang.org/protobuf v1.27.1
@@ -38,7 +37,6 @@ require (
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/imdario/mergo v0.3.11 // indirect
 	github.com/jefferai/isbadcipher v0.0.0-20190226160619-51d2077c035f // indirect
-	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.6 // indirect
 	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/mitchellh/cli v1.1.2 // indirect

--- a/configutil/go.sum
+++ b/configutil/go.sum
@@ -84,8 +84,8 @@ github.com/hashicorp/go-secure-stdlib/listenerutil v0.1.4/go.mod h1:myX7XYMJRIP4
 github.com/hashicorp/go-secure-stdlib/parseutil v0.1.1/go.mod h1:QmrqtbKuxxSWTN3ETMPuB+VtEiBJ/A9XhoYGv8E1uD8=
 github.com/hashicorp/go-secure-stdlib/parseutil v0.1.2 h1:Tz6v3Jb2DRnDCfifRSjYKG0m8dLdNq6bcDkB41en7nw=
 github.com/hashicorp/go-secure-stdlib/parseutil v0.1.2/go.mod h1:QmrqtbKuxxSWTN3ETMPuB+VtEiBJ/A9XhoYGv8E1uD8=
-github.com/hashicorp/go-secure-stdlib/pluginutil/v2 v2.0.0 h1:TszfJJ1vJWdvPkPxYivP5TUTkOaXziE1jTKGmfOck94=
-github.com/hashicorp/go-secure-stdlib/pluginutil/v2 v2.0.0/go.mod h1:Io+g8iYs//ESo5x2Gy1rTTYaIHUyCZD7h16K7DiOUI4=
+github.com/hashicorp/go-secure-stdlib/pluginutil/v2 v2.0.1-0.20220317202442-3050f509c668 h1:miRDvYME9g2fRv24O7TYpZpR30MCZJA0iBcJxjRis+s=
+github.com/hashicorp/go-secure-stdlib/pluginutil/v2 v2.0.1-0.20220317202442-3050f509c668/go.mod h1:Mh8pP9IH9qnBQSSH3PYtSkGq3+KlIuw5kAS9W8++BLc=
 github.com/hashicorp/go-secure-stdlib/reloadutil v0.1.1 h1:SMGUnbpAcat8rIKHkBPjfv81yC46a8eCNZ2hsR2l1EI=
 github.com/hashicorp/go-secure-stdlib/reloadutil v0.1.1/go.mod h1:Ch/bf00Qnx77MZd49JRgHYqHQjtEmTgGU2faufpVZb0=
 github.com/hashicorp/go-secure-stdlib/strutil v0.1.1 h1:nd0HIW15E6FG1MsnArYaHfuw9C2zgzM8LxkG5Ty/788=

--- a/configutil/go.sum
+++ b/configutil/go.sum
@@ -84,8 +84,8 @@ github.com/hashicorp/go-secure-stdlib/listenerutil v0.1.4/go.mod h1:myX7XYMJRIP4
 github.com/hashicorp/go-secure-stdlib/parseutil v0.1.1/go.mod h1:QmrqtbKuxxSWTN3ETMPuB+VtEiBJ/A9XhoYGv8E1uD8=
 github.com/hashicorp/go-secure-stdlib/parseutil v0.1.2 h1:Tz6v3Jb2DRnDCfifRSjYKG0m8dLdNq6bcDkB41en7nw=
 github.com/hashicorp/go-secure-stdlib/parseutil v0.1.2/go.mod h1:QmrqtbKuxxSWTN3ETMPuB+VtEiBJ/A9XhoYGv8E1uD8=
-github.com/hashicorp/go-secure-stdlib/pluginutil/v2 v2.0.1-0.20220317202442-3050f509c668 h1:miRDvYME9g2fRv24O7TYpZpR30MCZJA0iBcJxjRis+s=
-github.com/hashicorp/go-secure-stdlib/pluginutil/v2 v2.0.1-0.20220317202442-3050f509c668/go.mod h1:Mh8pP9IH9qnBQSSH3PYtSkGq3+KlIuw5kAS9W8++BLc=
+github.com/hashicorp/go-secure-stdlib/pluginutil/v2 v2.0.1-0.20220318133345-4b0c6b19f281 h1:Yp+M74XOcvLcpIF1yQXjEJq4lbG3F7F2fUmpNSZ/+Bo=
+github.com/hashicorp/go-secure-stdlib/pluginutil/v2 v2.0.1-0.20220318133345-4b0c6b19f281/go.mod h1:Mh8pP9IH9qnBQSSH3PYtSkGq3+KlIuw5kAS9W8++BLc=
 github.com/hashicorp/go-secure-stdlib/reloadutil v0.1.1 h1:SMGUnbpAcat8rIKHkBPjfv81yC46a8eCNZ2hsR2l1EI=
 github.com/hashicorp/go-secure-stdlib/reloadutil v0.1.1/go.mod h1:Ch/bf00Qnx77MZd49JRgHYqHQjtEmTgGU2faufpVZb0=
 github.com/hashicorp/go-secure-stdlib/strutil v0.1.1 h1:nd0HIW15E6FG1MsnArYaHfuw9C2zgzM8LxkG5Ty/788=

--- a/configutil/kms.go
+++ b/configutil/kms.go
@@ -271,7 +271,7 @@ func configureWrapper(
 		return nil, cleanup, fmt.Errorf("error setting configuration on the kms plugin: %w", err)
 	}
 	kmsInfo := wrapperConfigResult.GetMetadata()
-	if len(kmsInfo) > 0 {
+	if len(kmsInfo) > 0 && infoKeys != nil && info != nil && *info != nil {
 		populateInfo(configKMS, infoKeys, info, kmsInfo)
 	}
 

--- a/configutil/testplugins/aead/main.go
+++ b/configutil/testplugins/aead/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	gkwp "github.com/hashicorp/go-kms-wrapping/plugin/v2"
+	aead "github.com/hashicorp/go-kms-wrapping/v2/aead"
+)
+
+func main() {
+	if err := gkwp.ServePlugin(aead.NewWrapper()); err != nil {
+		fmt.Println("Error serving plugin", err)
+		os.Exit(1)
+	}
+	os.Exit(0)
+}

--- a/pluginutil/go.mod
+++ b/pluginutil/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/hashicorp/go-plugin v1.4.3
 	github.com/stretchr/testify v1.7.0
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 )
 
 require (

--- a/pluginutil/go.sum
+++ b/pluginutil/go.sum
@@ -84,6 +84,7 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/pluginutil/options.go
+++ b/pluginutil/options.go
@@ -111,15 +111,17 @@ func WithPluginFile(with PluginFileInfo) Option {
 			return errors.New("plugin file checksum is empty")
 		}
 
-		switch with.HashType {
-		case HashTypeSha2256,
-			HashTypeSha2384,
-			HashTypeSha2512,
-			HashTypeSha3256,
-			HashTypeSha3384,
-			HashTypeSha3512:
+		switch with.HashMethod {
+		case HashMethodUnspecified:
+			with.HashMethod = HashMethodSha2256
+		case HashMethodSha2256,
+			HashMethodSha2384,
+			HashMethodSha2512,
+			HashMethodSha3256,
+			HashMethodSha3384,
+			HashMethodSha3512:
 		default:
-			return fmt.Errorf("unsupported hash type %q", string(with.HashType))
+			return fmt.Errorf("unsupported hash method %q", string(with.HashMethod))
 		}
 		info, err := os.Stat(with.Path)
 		if err != nil {

--- a/pluginutil/options_test.go
+++ b/pluginutil/options_test.go
@@ -111,7 +111,7 @@ func Test_GetOpts(t *testing.T) {
 			name            string
 			plugin          PluginFileInfo
 			wantErrContains string
-			wantHashType    HashType
+			wantHashMethod  HashMethod
 		}{
 			{
 				name:            "no name",
@@ -136,52 +136,52 @@ func Test_GetOpts(t *testing.T) {
 			{
 				name: "bad hash type",
 				plugin: PluginFileInfo{
-					Name:     "testing",
-					Path:     file.Name(),
-					Checksum: []byte("foobar"),
-					HashType: "foobar",
+					Name:       "testing",
+					Path:       file.Name(),
+					Checksum:   []byte("foobar"),
+					HashMethod: "foobar",
 				},
-				wantErrContains: "unsupported hash type",
+				wantErrContains: "unsupported hash method",
 			},
 			{
 				name: "invalid path - missing",
 				plugin: PluginFileInfo{
-					Name:     "testing",
-					Path:     file.Name() + ".foobar",
-					Checksum: []byte("foobar"),
-					HashType: HashTypeSha2384,
+					Name:       "testing",
+					Path:       file.Name() + ".foobar",
+					Checksum:   []byte("foobar"),
+					HashMethod: HashMethodSha2384,
 				},
 				wantErrContains: "not found on filesystem",
 			},
 			{
 				name: "invalid path - dir",
 				plugin: PluginFileInfo{
-					Name:     "testing",
-					Path:     currDir,
-					Checksum: []byte("foobar"),
-					HashType: HashTypeSha2384,
+					Name:       "testing",
+					Path:       currDir,
+					Checksum:   []byte("foobar"),
+					HashMethod: HashMethodSha2384,
 				},
 				wantErrContains: "is a directory",
 			},
 			{
 				name: "unspecified hash type",
 				plugin: PluginFileInfo{
-					Name:     "testing",
-					Path:     file.Name(),
-					Checksum: []byte("foobar"),
-					HashType: HashTypeSha2384,
+					Name:       "testing",
+					Path:       file.Name(),
+					Checksum:   []byte("foobar"),
+					HashMethod: HashMethodSha2384,
 				},
-				wantHashType: HashTypeSha2256,
+				wantHashMethod: HashMethodSha2256,
 			},
 			{
 				name: "specified hash type",
 				plugin: PluginFileInfo{
-					Name:     "testing",
-					Path:     file.Name(),
-					Checksum: []byte("foobar"),
-					HashType: HashTypeSha3384,
+					Name:       "testing",
+					Path:       file.Name(),
+					Checksum:   []byte("foobar"),
+					HashMethod: HashMethodSha3384,
 				},
-				wantHashType: HashTypeSha3384,
+				wantHashMethod: HashMethodSha3384,
 			},
 		}
 		for _, tc := range testCases {

--- a/pluginutil/pluginutil.go
+++ b/pluginutil/pluginutil.go
@@ -181,7 +181,7 @@ func CreatePlugin(plugin *PluginInfo, opt ...Option) (interface{}, func() error,
 	case plugin.PluginClientCreationFunc == nil:
 		return nil, nil, fmt.Errorf("plugin creation func not provided")
 
-	// Either we need to have either a validated FS to read from or secure config
+	// Either we need to have a validated FS to read from or a secure config
 	case plugin.ContainerFs == nil && plugin.SecureConfig == nil:
 		return nil, nil, fmt.Errorf("plugin container filesystem and secure config are both nil")
 

--- a/pluginutil/pluginutil.go
+++ b/pluginutil/pluginutil.go
@@ -18,16 +18,17 @@ import (
 	"golang.org/x/crypto/sha3"
 )
 
-// HashType is a string representation of a hash type
-type HashType string
+// HashMethod is a string representation of a hash method
+type HashMethod string
 
 const (
-	HashTypeSha2256 HashType = "sha2-256"
-	HashTypeSha2384 HashType = "sha2-384"
-	HashTypeSha2512 HashType = "sha2-512"
-	HashTypeSha3256 HashType = "sha3-256"
-	HashTypeSha3384 HashType = "sha3-384"
-	HashTypeSha3512 HashType = "sha3-512"
+	HashMethodUnspecified HashMethod = ""
+	HashMethodSha2256     HashMethod = "sha2-256"
+	HashMethodSha2384     HashMethod = "sha2-384"
+	HashMethodSha2512     HashMethod = "sha2-512"
+	HashMethodSha3256     HashMethod = "sha3-256"
+	HashMethodSha3384     HashMethod = "sha3-384"
+	HashMethodSha3512     HashMethod = "sha3-512"
 )
 
 // PluginFileInfo represents user-specified on-disk file information. Note that
@@ -35,10 +36,10 @@ const (
 // is in configutil to avoid pulling in go-kms-wrapping as a dep of this
 // package.
 type PluginFileInfo struct {
-	Name     string
-	Path     string
-	Checksum []byte
-	HashType HashType
+	Name       string
+	Path       string
+	Checksum   []byte
+	HashMethod HashMethod
 }
 
 type (
@@ -112,18 +113,18 @@ func BuildPluginMap(opt ...Option) (map[string]*PluginInfo, error) {
 		case sourceInfo.pluginFileInfo != nil:
 			fileInfo := sourceInfo.pluginFileInfo
 			var h hash.Hash
-			switch fileInfo.HashType {
-			case HashTypeSha2256:
+			switch fileInfo.HashMethod {
+			case HashMethodSha2256:
 				h = sha256.New()
-			case HashTypeSha2384:
+			case HashMethodSha2384:
 				h = sha512.New384()
-			case HashTypeSha2512:
+			case HashMethodSha2512:
 				h = sha512.New()
-			case HashTypeSha3256:
+			case HashMethodSha3256:
 				h = sha3.New256()
-			case HashTypeSha3384:
+			case HashMethodSha3384:
 				h = sha3.New384()
-			case HashTypeSha3512:
+			case HashMethodSha3512:
 				h = sha3.New512()
 			}
 			pluginMap[fileInfo.Name] = &PluginInfo{

--- a/pluginutil/pluginutil.go
+++ b/pluginutil/pluginutil.go
@@ -3,7 +3,10 @@ package pluginutil
 import (
 	"bytes"
 	"compress/gzip"
+	"crypto/sha256"
+	"crypto/sha512"
 	"fmt"
+	"hash"
 	"io/fs"
 	"io/ioutil"
 	"os"
@@ -12,7 +15,31 @@ import (
 	"strings"
 
 	gp "github.com/hashicorp/go-plugin"
+	"golang.org/x/crypto/sha3"
 )
+
+// HashType is a string representation of a hash type
+type HashType string
+
+const (
+	HashTypeSha2256 HashType = "sha2-256"
+	HashTypeSha2384 HashType = "sha2-384"
+	HashTypeSha2512 HashType = "sha2-512"
+	HashTypeSha3256 HashType = "sha3-256"
+	HashTypeSha3384 HashType = "sha3-384"
+	HashTypeSha3512 HashType = "sha3-512"
+)
+
+// PluginFileInfo represents user-specified on-disk file information. Note that
+// testing for how this works in go-plugin, e.g. passing it into SecureConfig,
+// is in configutil to avoid pulling in go-kms-wrapping as a dep of this
+// package.
+type PluginFileInfo struct {
+	Name     string
+	Path     string
+	Checksum []byte
+	HashType HashType
+}
 
 type (
 	// InmemCreationFunc is a function that, when run, returns the thing you
@@ -33,7 +60,8 @@ type (
 // function.
 type PluginInfo struct {
 	ContainerFs              fs.FS
-	Filename                 string
+	Path                     string
+	SecureConfig             *gp.SecureConfig
 	InmemCreationFunc        InmemCreationFunc
 	PluginClientCreationFunc PluginClientCreationFunc
 }
@@ -72,13 +100,39 @@ func BuildPluginMap(opt ...Option) (map[string]*PluginInfo, error) {
 				}
 				pluginMap[pluginType] = &PluginInfo{
 					ContainerFs:              sourceInfo.pluginFs,
-					Filename:                 entry.Name(),
+					Path:                     entry.Name(),
 					PluginClientCreationFunc: opts.withPluginClientCreationFunc,
 				}
 			}
 		case sourceInfo.pluginMap != nil:
 			for k, creationFunc := range sourceInfo.pluginMap {
 				pluginMap[k] = &PluginInfo{InmemCreationFunc: creationFunc}
+			}
+
+		case sourceInfo.pluginFileInfo != nil:
+			fileInfo := sourceInfo.pluginFileInfo
+			var h hash.Hash
+			switch fileInfo.HashType {
+			case HashTypeSha2256:
+				h = sha256.New()
+			case HashTypeSha2384:
+				h = sha512.New384()
+			case HashTypeSha2512:
+				h = sha512.New()
+			case HashTypeSha3256:
+				h = sha3.New256()
+			case HashTypeSha3384:
+				h = sha3.New384()
+			case HashTypeSha3512:
+				h = sha3.New512()
+			}
+			pluginMap[fileInfo.Name] = &PluginInfo{
+				Path:                     fileInfo.Path,
+				PluginClientCreationFunc: opts.withPluginClientCreationFunc,
+				SecureConfig: &gp.SecureConfig{
+					Checksum: fileInfo.Checksum,
+					Hash:     h,
+				},
 			}
 		}
 	}
@@ -101,28 +155,50 @@ func BuildPluginMap(opt ...Option) (map[string]*PluginInfo, error) {
 // the plugin. In the case of an in-memory plugin it will be nil, however, if
 // the plugin is via RPC it will ensure that it is torn down properly.
 func CreatePlugin(plugin *PluginInfo, opt ...Option) (interface{}, func() error, error) {
-	switch {
-	case plugin == nil:
-		return nil, nil, fmt.Errorf("plugin is nil")
-
-	case plugin.InmemCreationFunc != nil:
-		raw, err := plugin.InmemCreationFunc()
-		return raw, nil, err
-
-	case plugin.ContainerFs == nil:
-		return nil, nil, fmt.Errorf("plugin container filesystem is nil")
-
-	case plugin.Filename == "" || plugin.PluginClientCreationFunc == nil:
-		return nil, nil, fmt.Errorf("no inmem creation func and either filename or plugin creation func not provided")
-	}
-
 	opts, err := GetOpts(opt...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error parsing plugin options: %w", err)
 	}
 
-	// Open and basic validation
-	file, err := plugin.ContainerFs.Open(plugin.Filename)
+	var file fs.File
+	var name string
+
+	switch {
+	case plugin == nil:
+		return nil, nil, fmt.Errorf("plugin is nil")
+
+	// Prioritize in-memory functions
+	case plugin.InmemCreationFunc != nil:
+		raw, err := plugin.InmemCreationFunc()
+		return raw, nil, err
+
+	// If not in-memory we need a filename, whether direct on disk or from a container FS
+	case plugin.Path == "":
+		return nil, nil, fmt.Errorf("no inmem creation func and file path not provided")
+
+	// We need the client creation func to use once we've spun out the plugin
+	case plugin.PluginClientCreationFunc == nil:
+		return nil, nil, fmt.Errorf("plugin creation func not provided")
+
+	// Either we need to have either a validated FS to read from or secure config
+	case plugin.ContainerFs == nil && plugin.SecureConfig == nil:
+		return nil, nil, fmt.Errorf("plugin container filesystem and secure config are both nil")
+
+	// If we have a constructed filesystem, read from there
+	case plugin.ContainerFs != nil:
+		file, err = plugin.ContainerFs.Open(plugin.Path)
+		name = plugin.Path
+
+	// If we have secure config, read from disk
+	case plugin.SecureConfig != nil:
+		file, err = os.Open(plugin.Path)
+		name = filepath.Base(plugin.Path)
+
+	default:
+		return nil, nil, fmt.Errorf("unhandled path in create plugin switch")
+	}
+
+	// This is the error from opening the file
 	if err != nil {
 		return nil, nil, err
 	}
@@ -147,7 +223,7 @@ func CreatePlugin(plugin *PluginInfo, opt ...Option) (interface{}, func() error,
 	}
 
 	// If it's compressed, uncompress it
-	if strings.HasSuffix(plugin.Filename, ".gz") {
+	if strings.HasSuffix(name, ".gz") {
 		gzipReader, err := gzip.NewReader(bytes.NewReader(buf))
 		if err != nil {
 			return nil, nil, fmt.Errorf("error creating gzip decompression reader: %w", err)
@@ -177,7 +253,7 @@ func CreatePlugin(plugin *PluginInfo, opt ...Option) (interface{}, func() error,
 		}
 		dir = tmpDir
 	}
-	pluginPath := filepath.Join(dir, plugin.Filename)
+	pluginPath := filepath.Join(dir, name)
 	if runtime.GOOS == "windows" {
 		pluginPath += ".exe"
 	}
@@ -185,8 +261,12 @@ func CreatePlugin(plugin *PluginInfo, opt ...Option) (interface{}, func() error,
 		return nil, cleanup, fmt.Errorf("error writing out plugin for execution: %w", err)
 	}
 
-	// Execute the plugin
-	client, err := plugin.PluginClientCreationFunc(pluginPath, opt...)
+	// Execute the plugin, passing in secure config if available
+	creationFuncOpts := opt
+	if plugin.SecureConfig != nil {
+		creationFuncOpts = append(creationFuncOpts, WithSecureConfig(plugin.SecureConfig))
+	}
+	client, err := plugin.PluginClientCreationFunc(pluginPath, creationFuncOpts...)
 	if err != nil {
 		return nil, cleanup, fmt.Errorf("error fetching kms plugin client: %w", err)
 	}


### PR DESCRIPTION
This contains two items:

1. In pluginutil, allows a direct plugin path to be specified, along with a (required) checksum and (optional) hash method used to generate the checksum. This is via an option that then factors into building the plugin map, and some plugin launching changes to understand these types.
2. In configutil, support for this new feature for KMS plugins. Additionally, the ability to specify this information within KMS blocks in HCL.

Tagging @jimlambrt for review, @calvn and @sgmiller mostly for heads-up.