### PR TITLE
bug(parseutil): SafeParseIntSlice leading zeros

### DIFF
--- a/parseutil/parseutil.go
+++ b/parseutil/parseutil.go
@@ -493,7 +493,7 @@ func SafeParseIntSlice(in interface{}, elements int) ([]int, error) {
 		return nil, err
 	}
 
-	var result = make([]int, len(raw))
+	var result = make([]int, 0, len(raw))
 	for _, element := range raw {
 		result = append(result, int(element))
 	}

--- a/parseutil/parseutil_test.go
+++ b/parseutil/parseutil_test.go
@@ -540,10 +540,26 @@ func Test_ParseIntSlice(t *testing.T) {
 			t.Errorf("input %v parsed as %v, expected %v", tc.inp, outp, tc.expected)
 			continue
 		}
-		_, err = SafeParseIntSliceRange(tc.inp, 0 /* min */, 5 /* max */, 10 /* num elements */)
+		expected, err := SafeParseIntSliceRange(tc.inp, 0 /* min */, 5 /* max */, 10 /* num elements */)
 		if err == nil != tc.ranged {
 			t.Errorf("no ranged slice error for %v", tc.inp)
 			continue
+		}
+		if err == nil {
+			actual, err := SafeParseIntSlice(tc.inp, 10 /* num elements */)
+			if err != nil {
+				t.Errorf("got unexpected err from SafeParseIntSlice: %v", err)
+			}
+
+			if len(expected) != len(actual) {
+				t.Errorf("for input %v, expected %v but got %v in SafeParseIntSliceRange<->SafeParseIntSlice compat test; different number of elements", tc.inp, expected, actual)
+			}
+
+			for index, elem := range expected {
+				if elem != int64(actual[index]) {
+					t.Errorf("for input %v, expected %v but got %v in SafeParseIntSliceRange<->SafeParseIntSlice compat test; differs at index %d: %v", tc.inp, expected, actual, elem, actual[index])
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
Due to creating a slice with the specified number of elements (rather
than a capacity hint), `SafeParseIntSlice` returned a slice with leading
zeros of length greater than was passed, rather than the correct value.

`Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>`

---

Of course, the one function I didn't test has the bug... Thanks to @Gabrielopesantos in https://github.com/hashicorp/vault/pull/15561 for catching this!

@sgmiller We'll need to bump this in Vault on both 1.12.x and 1.11.x. 