### PR TITLE
Propagate plugin options in ConfigureWrapper

### DIFF
--- a/configutil/Makefile
+++ b/configutil/Makefile
@@ -2,7 +2,6 @@ PLUGIN_TMP_DIR := $(shell mktemp -d)
 
 test-plugin:
 	go build -o "${PLUGIN_TMP_DIR}/aeadplugin" testplugins/aead/main.go
-	PLUGIN_PATH="${PLUGIN_TMP_DIR}/aeadplugin" go test -v -run TestFilePlugin
-
+	PLUGIN_PATH="${PLUGIN_TMP_DIR}/aeadplugin" go test -v -run 'TestFilePlugin|TestConfigureWrapperPropagatesOptions'
 
 .PHONY: test-plugin

--- a/configutil/kms.go
+++ b/configutil/kms.go
@@ -323,7 +323,7 @@ func configureWrapper(
 	}
 
 	// Create the plugin and cleanup func
-	plugClient, cleanup, err := pluginutil.CreatePlugin(plug)
+	plugClient, cleanup, err := pluginutil.CreatePlugin(plug, pluginOpts...)
 	if err != nil {
 		return nil, cleanup, err
 	}

--- a/configutil/kms_test.go
+++ b/configutil/kms_test.go
@@ -1,0 +1,58 @@
+package configutil
+
+import (
+	"context"
+	"crypto/sha256"
+	"os"
+	"testing"
+
+	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
+	"github.com/hashicorp/go-secure-stdlib/pluginutil/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigureWrapperPropagatesOptions(t *testing.T) {
+	pluginPath := os.Getenv("PLUGIN_PATH")
+	if pluginPath == "" {
+		t.Skipf("skipping plugin test as no PLUGIN_PATH specified")
+	}
+	assert, require := assert.New(t), require.New(t)
+	ctx := context.Background()
+
+	pluginBytes, err := os.ReadFile(pluginPath)
+	require.NoError(err)
+	sha2256Bytes := sha256.Sum256(pluginBytes)
+	kms := &KMS{
+		Type:    string(wrapping.WrapperTypeAead),
+		Purpose: []string{"foobar"},
+	}
+	tmpDir := t.TempDir()
+	pluginOptions := []pluginutil.Option{
+		pluginutil.WithPluginExecutionDirectory(tmpDir),
+		pluginutil.WithPluginFile(
+			pluginutil.PluginFileInfo{
+				Name:       "aead",
+				Path:       pluginPath,
+				Checksum:   sha2256Bytes[:],
+				HashMethod: pluginutil.HashMethodSha2256,
+			}),
+	}
+	wrapper, cleanup, err := configureWrapper(ctx, kms, nil, nil, WithPluginOptions(pluginOptions...))
+	require.NoError(err)
+	require.NotNil(wrapper)
+	require.NotNil(cleanup)
+	t.Cleanup(func() {
+		err := cleanup()
+		require.NoError(err)
+	})
+	files, err := os.ReadDir(tmpDir)
+	require.NoError(err)
+	require.Len(files, 1)
+	assert.Equal("aeadplugin", files[0].Name())
+	blob, err := wrapper.Encrypt(ctx, []byte("secret"))
+	require.NoError(err)
+	decrypted, err := wrapper.Decrypt(ctx, blob)
+	require.NoError(err)
+	assert.EqualValues("secret", decrypted)
+}

--- a/configutil/testplugins/aead/main.go
+++ b/configutil/testplugins/aead/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"crypto/aes"
+	"crypto/cipher"
 	"fmt"
 	"os"
 
@@ -9,7 +11,19 @@ import (
 )
 
 func main() {
-	if err := gkwp.ServePlugin(aead.NewWrapper()); err != nil {
+	block, err := aes.NewCipher([]byte("1234567890123456"))
+	if err != nil {
+		fmt.Println("Error creating AES block", err)
+		os.Exit(1)
+	}
+	aeadCipher, err := cipher.NewGCM(block)
+	if err != nil {
+		fmt.Println("Error creating GCM cipher", err)
+		os.Exit(1)
+	}
+	wrapper := aead.NewWrapper()
+	wrapper.SetAead(aeadCipher)
+	if err := gkwp.ServePlugin(wrapper); err != nil {
 		fmt.Println("Error serving plugin", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
It seems we forgot to include this when migrating to the new kms wrapper in #32.

## [fix: Make testplugin functional](https://github.com/hashicorp/go-secure-stdlib/commit/1e6b8d7bb1e0815462b523c8d2a6734aa0837f80)

The testplugin as previously implemented didn't support the Encrypt or Decrypt methods, since it did not have an AEAD cipher configured. This change configures an AES cipher with a hardcoded key, so that we can do Encrypt
and Decrypt operations in tests.

## [fix: Propagate plugin options in configureWrapper](https://github.com/hashicorp/go-secure-stdlib/commit/b67992d89c133fbc0d9d1ed5cffc0cf39dbde1fd)

The configureWrapper was not propagating plugin options. Propagate these options and add a test to ensure they work.