### PR TITLE
Add Custom Headers To Config Parser

### DIFF
--- a/configutil/config_test.go
+++ b/configutil/config_test.go
@@ -53,6 +53,8 @@ func TestParseConfig(t *testing.T) {
 				custom_api_response_headers {
 					"default" = {
 						"test" = ["default value", "default value 2"]
+						// try unsetting this one
+						"x-content-type-options" = []
 					}
 					"200" = {
 						"test" = ["200 value"]
@@ -70,7 +72,8 @@ func TestParseConfig(t *testing.T) {
 				custom_ui_response_headers {
 					"default" = {
 						"test" =          ["ui default value"]
-						"cache-control" = ["max-age=604800"]
+						// try overwriting this one
+						"CACHE-CONTROL" = ["max-age=604800"]
 					}
 					"200" = {
 						"test" = ["ui 200 value"]
@@ -94,7 +97,10 @@ func TestParseConfig(t *testing.T) {
 							"custom_api_response_headers": []map[string]interface{}{
 								{
 									"default": []map[string]interface{}{
-										{"test": []interface{}{"default value", "default value 2"}},
+										{
+											"test":                   []interface{}{"default value", "default value 2"},
+											"x-content-type-options": []interface{}{},
+										},
 									},
 									"200": []map[string]interface{}{
 										{"test": []interface{}{"200 value"}},
@@ -115,7 +121,7 @@ func TestParseConfig(t *testing.T) {
 									"default": []map[string]interface{}{
 										{
 											"test":          []interface{}{"ui default value"},
-											"cache-control": []interface{}{"max-age=604800"},
+											"CACHE-CONTROL": []interface{}{"max-age=604800"},
 										},
 									},
 									"200": []map[string]interface{}{
@@ -133,46 +139,45 @@ func TestParseConfig(t *testing.T) {
 								},
 							},
 						},
-						CustomApiResponseHeaders: map[int]map[string]string{
+						CustomApiResponseHeaders: map[int]map[string][]string{
 							0: {
-								"Test":                      "default value; default value 2",
-								"Content-Security-Policy":   "default-src 'none'",
-								"X-Content-Type-Options":    "nosniff",
-								"Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-								"Cache-Control":             "no-store",
+								"Test":                      {"default value", "default value 2"},
+								"Content-Security-Policy":   {"default-src 'none'"},
+								"Strict-Transport-Security": {"max-age=31536000; includeSubDomains"},
+								"Cache-Control":             {"no-store"},
 							},
 							200: {
-								"Test": "200 value",
+								"Test": {"200 value"},
 							},
 							2: {
-								"Test": "2xx value",
+								"Test": {"2xx value"},
 							},
 							401: {
-								"Test": "401 value",
+								"Test": {"401 value"},
 							},
 							4: {
-								"Test": "4xx value",
+								"Test": {"4xx value"},
 							},
 						},
-						CustomUiResponseHeaders: map[int]map[string]string{
+						CustomUiResponseHeaders: map[int]map[string][]string{
 							0: {
-								"Test":                      "ui default value",
-								"Content-Security-Policy":   "default-src 'none'; script-src 'self'; frame-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:*; style-src 'self'; media-src 'self'; manifest-src 'self'; style-src-attr 'self'; frame-ancestors 'self'",
-								"X-Content-Type-Options":    "nosniff",
-								"Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-								"Cache-Control":             "max-age=604800",
+								"Test":                      {"ui default value"},
+								"Content-Security-Policy":   {"default-src 'none'; script-src 'self'; frame-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:*; style-src 'self'; media-src 'self'; manifest-src 'self'; style-src-attr 'self'; frame-ancestors 'self'"},
+								"X-Content-Type-Options":    {"nosniff"},
+								"Strict-Transport-Security": {"max-age=31536000; includeSubDomains"},
+								"Cache-Control":             {"max-age=604800"},
 							},
 							200: {
-								"Test": "ui 200 value",
+								"Test": {"ui 200 value"},
 							},
 							2: {
-								"Test": "ui 2xx value",
+								"Test": {"ui 2xx value"},
 							},
 							401: {
-								"Test": "ui 401 value",
+								"Test": {"ui 401 value"},
 							},
 							4: {
-								"Test": "ui 4xx value",
+								"Test": {"ui 4xx value"},
 							},
 						},
 					},

--- a/configutil/config_test.go
+++ b/configutil/config_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-secure-stdlib/listenerutil"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -44,6 +46,104 @@ func TestParseConfig(t *testing.T) {
 			expSharedConfig: nil,
 			expErr:          true,
 			expErrIs:        os.ErrNotExist,
+		},
+		{
+			name: "custom headers parsed and set correctly",
+			in: `
+			listener "tcp" {
+				custom_api_response_headers {
+					"default" = {
+						"test" = ["default value", "default value 2"]
+					}
+					"200" = {
+						"test" = ["200 value"]
+					}
+					"401" = {
+						"test" = ["401 value"]
+					}
+				}
+				custom_ui_response_headers {
+					"default" = {
+						"test" =          ["ui default value"]
+						"cache-control" = ["max-age=604800"]
+					}
+					"200" = {
+						"test" = ["ui 200 value"]
+					}
+					"401" = {
+						"test" = ["ui 401 value"]
+					}
+				}
+			}`,
+			expSharedConfig: &SharedConfig{
+				Listeners: []*listenerutil.ListenerConfig{
+					{
+						Type: "tcp",
+						RawConfig: map[string]interface{}{
+							"custom_api_response_headers": []map[string]interface{}{
+								{
+									"default": []map[string]interface{}{
+										{"test": []interface{}{"default value", "default value 2"}},
+									},
+									"200": []map[string]interface{}{
+										{"test": []interface{}{"200 value"}},
+									},
+									"401": []map[string]interface{}{
+										{"test": []interface{}{"401 value"}},
+									},
+								},
+							},
+							"custom_ui_response_headers": []map[string]interface{}{
+								{
+									"default": []map[string]interface{}{
+										{
+											"test":          []interface{}{"ui default value"},
+											"cache-control": []interface{}{"max-age=604800"},
+										},
+									},
+									"200": []map[string]interface{}{
+										{"test": []interface{}{"ui 200 value"}},
+									},
+									"401": []map[string]interface{}{
+										{"test": []interface{}{"ui 401 value"}},
+									},
+								},
+							},
+						},
+						CustomApiResponseHeaders: map[string]map[string]string{
+							"default": {
+								"Test":                      "default value; default value 2",
+								"Content-Security-Policy":   "default-src 'none'",
+								"X-Content-Type-Options":    "nosniff",
+								"Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+								"Cache-Control":             "no-store",
+							},
+							"200": {
+								"Test": "200 value",
+							},
+							"401": {
+								"Test": "401 value",
+							},
+						},
+						CustomUiResponseHeaders: map[string]map[string]string{
+							"default": {
+								"Test":                      "ui default value",
+								"Content-Security-Policy":   "default-src 'none'; script-src 'self'; frame-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:*; style-src 'self'; media-src 'self'; manifest-src 'self'; style-src-attr 'self'; frame-ancestors 'self'",
+								"X-Content-Type-Options":    "nosniff",
+								"Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+								"Cache-Control":             "max-age=604800",
+							},
+							"200": {
+								"Test": "ui 200 value",
+							},
+							"401": {
+								"Test": "ui 401 value",
+							},
+						},
+					},
+				},
+			},
+			expErr: false,
 		},
 	}
 

--- a/configutil/config_test.go
+++ b/configutil/config_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-secure-stdlib/listenerutil"
-
 	"github.com/stretchr/testify/require"
 )
 
@@ -58,8 +57,14 @@ func TestParseConfig(t *testing.T) {
 					"200" = {
 						"test" = ["200 value"]
 					}
+					"2xx" = {
+						"test" = ["2xx value"]
+					}
 					"401" = {
 						"test" = ["401 value"]
+					}
+					"4xx" = {
+						"test" = ["4xx value"]
 					}
 				}
 				custom_ui_response_headers {
@@ -70,8 +75,14 @@ func TestParseConfig(t *testing.T) {
 					"200" = {
 						"test" = ["ui 200 value"]
 					}
+					"2xx" = {
+						"test" = ["ui 2xx value"]
+					}
 					"401" = {
 						"test" = ["ui 401 value"]
+					}
+					"4xx" = {
+						"test" = ["ui 4xx value"]
 					}
 				}
 			}`,
@@ -88,8 +99,14 @@ func TestParseConfig(t *testing.T) {
 									"200": []map[string]interface{}{
 										{"test": []interface{}{"200 value"}},
 									},
+									"2xx": []map[string]interface{}{
+										{"test": []interface{}{"2xx value"}},
+									},
 									"401": []map[string]interface{}{
 										{"test": []interface{}{"401 value"}},
+									},
+									"4xx": []map[string]interface{}{
+										{"test": []interface{}{"4xx value"}},
 									},
 								},
 							},
@@ -104,40 +121,58 @@ func TestParseConfig(t *testing.T) {
 									"200": []map[string]interface{}{
 										{"test": []interface{}{"ui 200 value"}},
 									},
+									"2xx": []map[string]interface{}{
+										{"test": []interface{}{"ui 2xx value"}},
+									},
 									"401": []map[string]interface{}{
 										{"test": []interface{}{"ui 401 value"}},
+									},
+									"4xx": []map[string]interface{}{
+										{"test": []interface{}{"ui 4xx value"}},
 									},
 								},
 							},
 						},
-						CustomApiResponseHeaders: map[string]map[string]string{
-							"default": {
+						CustomApiResponseHeaders: map[int]map[string]string{
+							0: {
 								"Test":                      "default value; default value 2",
 								"Content-Security-Policy":   "default-src 'none'",
 								"X-Content-Type-Options":    "nosniff",
 								"Strict-Transport-Security": "max-age=31536000; includeSubDomains",
 								"Cache-Control":             "no-store",
 							},
-							"200": {
+							200: {
 								"Test": "200 value",
 							},
-							"401": {
+							2: {
+								"Test": "2xx value",
+							},
+							401: {
 								"Test": "401 value",
 							},
+							4: {
+								"Test": "4xx value",
+							},
 						},
-						CustomUiResponseHeaders: map[string]map[string]string{
-							"default": {
+						CustomUiResponseHeaders: map[int]map[string]string{
+							0: {
 								"Test":                      "ui default value",
 								"Content-Security-Policy":   "default-src 'none'; script-src 'self'; frame-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:*; style-src 'self'; media-src 'self'; manifest-src 'self'; style-src-attr 'self'; frame-ancestors 'self'",
 								"X-Content-Type-Options":    "nosniff",
 								"Strict-Transport-Security": "max-age=31536000; includeSubDomains",
 								"Cache-Control":             "max-age=604800",
 							},
-							"200": {
+							200: {
 								"Test": "ui 200 value",
 							},
-							"401": {
+							2: {
+								"Test": "ui 2xx value",
+							},
+							401: {
 								"Test": "ui 401 value",
+							},
+							4: {
+								"Test": "ui 4xx value",
 							},
 						},
 					},

--- a/configutil/config_test.go
+++ b/configutil/config_test.go
@@ -1,6 +1,7 @@
 package configutil
 
 import (
+	"net/http"
 	"os"
 	"testing"
 
@@ -139,7 +140,7 @@ func TestParseConfig(t *testing.T) {
 								},
 							},
 						},
-						CustomApiResponseHeaders: map[int]map[string][]string{
+						CustomApiResponseHeaders: map[int]http.Header{
 							0: {
 								"Test":                      {"default value", "default value 2"},
 								"Content-Security-Policy":   {"default-src 'none'"},
@@ -159,7 +160,7 @@ func TestParseConfig(t *testing.T) {
 								"Test": {"4xx value"},
 							},
 						},
-						CustomUiResponseHeaders: map[int]map[string][]string{
+						CustomUiResponseHeaders: map[int]http.Header{
 							0: {
 								"Test":                      {"ui default value"},
 								"Content-Security-Policy":   {"default-src 'none'; script-src 'self'; frame-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:*; style-src 'self'; media-src 'self'; manifest-src 'self'; style-src-attr 'self'; frame-ancestors 'self'"},

--- a/configutil/go.mod
+++ b/configutil/go.mod
@@ -2,9 +2,6 @@ module github.com/hashicorp/go-secure-stdlib/configutil/v2
 
 go 1.17
 
-// TODO: remove
-replace github.com/hashicorp/go-secure-stdlib/listenerutil => ../listenerutil
-
 require (
 	github.com/hashicorp/go-hclog v1.1.0
 	github.com/hashicorp/go-kms-wrapping/plugin/v2 v2.0.2

--- a/configutil/go.mod
+++ b/configutil/go.mod
@@ -2,6 +2,9 @@ module github.com/hashicorp/go-secure-stdlib/configutil/v2
 
 go 1.17
 
+// TODO: remove
+replace github.com/hashicorp/go-secure-stdlib/listenerutil => ../listenerutil
+
 require (
 	github.com/hashicorp/go-hclog v1.1.0
 	github.com/hashicorp/go-kms-wrapping/plugin/v2 v2.0.2

--- a/configutil/go.mod
+++ b/configutil/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/rogpeppe/go-internal v1.8.1 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
-	golang.org/x/sys v0.0.0-20220204135822-1c1b9b1eba6a // indirect
+	golang.org/x/sys v0.2.0 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/genproto v0.0.0-20220208230804-65c12eb4c068 // indirect
 	google.golang.org/grpc v1.44.0 // indirect

--- a/configutil/go.sum
+++ b/configutil/go.sum
@@ -61,6 +61,8 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=

--- a/configutil/go.sum
+++ b/configutil/go.sum
@@ -208,6 +208,8 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220204135822-1c1b9b1eba6a h1:ppl5mZgokTT8uPkmYOyEUmPTr3ypaKkg5eFOGrAmxxE=
 golang.org/x/sys v0.0.0-20220204135822-1c1b9b1eba6a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
+golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/configutil/go.sum
+++ b/configutil/go.sum
@@ -59,7 +59,6 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
@@ -83,8 +82,6 @@ github.com/hashicorp/go-plugin v1.4.3 h1:DXmvivbWD5qdiBts9TpBC7BYL1Aia5sxbRgQB+v
 github.com/hashicorp/go-plugin v1.4.3/go.mod h1:5fGEH17QVwTTcR0zV7yhDPLLmFX9YSZ38b18Udy6vYQ=
 github.com/hashicorp/go-secure-stdlib/base62 v0.1.2 h1:ET4pqyjiGmY09R5y+rSd70J2w45CtbWDNvGqWp/R3Ng=
 github.com/hashicorp/go-secure-stdlib/base62 v0.1.2/go.mod h1:EdWO6czbmthiwZ3/PUsDV+UD1D5IRU4ActiaWGwt0Yw=
-github.com/hashicorp/go-secure-stdlib/listenerutil v0.1.4 h1:6ajbq64FhrIJZ6prrff3upVVDil4yfCrnSKwTH0HIPE=
-github.com/hashicorp/go-secure-stdlib/listenerutil v0.1.4/go.mod h1:myX7XYMJRIP4PLHtYJiKMTJcKOX0M5ZJNwP0iw+l3uw=
 github.com/hashicorp/go-secure-stdlib/parseutil v0.1.1/go.mod h1:QmrqtbKuxxSWTN3ETMPuB+VtEiBJ/A9XhoYGv8E1uD8=
 github.com/hashicorp/go-secure-stdlib/parseutil v0.1.2 h1:Tz6v3Jb2DRnDCfifRSjYKG0m8dLdNq6bcDkB41en7nw=
 github.com/hashicorp/go-secure-stdlib/parseutil v0.1.2/go.mod h1:QmrqtbKuxxSWTN3ETMPuB+VtEiBJ/A9XhoYGv8E1uD8=
@@ -201,14 +198,12 @@ golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220204135822-1c1b9b1eba6a h1:ppl5mZgokTT8uPkmYOyEUmPTr3ypaKkg5eFOGrAmxxE=
 golang.org/x/sys v0.0.0-20220204135822-1c1b9b1eba6a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -226,7 +221,6 @@ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=

--- a/listenerutil/go.mod
+++ b/listenerutil/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/armon/go-radix v1.0.0 // indirect
+	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.1

--- a/listenerutil/go.mod
+++ b/listenerutil/go.mod
@@ -16,5 +16,5 @@ require (
 	github.com/mattn/go-colorable v0.1.6 // indirect
 	github.com/mitchellh/cli v1.1.2
 	github.com/stretchr/testify v1.7.0
-	golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980 // indirect
+	golang.org/x/sys v0.2.0 // indirect
 )

--- a/listenerutil/go.sum
+++ b/listenerutil/go.sum
@@ -78,6 +78,8 @@ golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980 h1:OjiUf46hAmXblsZdnoSXsEUSKU8r1UEzcL5RVZ4gO9Y=
 golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
+golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/listenerutil/go.sum
+++ b/listenerutil/go.sum
@@ -14,6 +14,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/listenerutil/handler.go
+++ b/listenerutil/handler.go
@@ -58,6 +58,7 @@ func (w *ResponseWriter) setCustomResponseHeaders(statusCode int) {
 	}
 
 	// Then setting the generic hundred-level headers
+	// Note: integer division always rounds down, so 499/100 = 4
 	if val, ok := sch[statusCode/100]; ok {
 		setter(val)
 	}

--- a/listenerutil/handler.go
+++ b/listenerutil/handler.go
@@ -1,0 +1,108 @@
+package listenerutil
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+)
+
+type ResponseWriter struct {
+	wrapped http.ResponseWriter
+	// headers contain a map of response code to header map such that
+	// headers[status][header name] = header value
+	// this map also contains values for hundred-level values in the format "1xx", "2xx", etc
+	headers       map[string]map[string]string
+	headerWritten bool
+}
+
+func (w *ResponseWriter) WriteHeader(statusCode int) {
+	w.headerWritten = true
+	w.setCustomResponseHeaders(statusCode)
+	w.wrapped.WriteHeader(statusCode)
+}
+
+func (w *ResponseWriter) Header() http.Header {
+	return w.wrapped.Header()
+}
+
+func (w *ResponseWriter) Write(data []byte) (int, error) {
+	// The default behavior of http.ResponseWriter.Write is such that if WriteHeader has not
+	// yet been called, it calls it with the below line. We will copy that logic so that our
+	// WriteHeader function is called rather than http.ResponseWriter.WriteHeader
+	if !w.headerWritten {
+		w.WriteHeader(http.StatusOK)
+	}
+	return w.wrapped.Write(data)
+}
+
+func (w *ResponseWriter) setCustomResponseHeaders(statusCode int) {
+	sch := w.headers
+	if sch == nil {
+		return
+	}
+
+	// Check the validity of the status code
+	if statusCode >= 600 || statusCode < 100 {
+		return
+	}
+
+	// Setter function to set headers
+	setter := func(headerMap map[string]string) {
+		for header, value := range headerMap {
+			w.Header().Set(header, value)
+		}
+	}
+
+	// Setting the default headers first
+	if val, ok := sch["default"]; ok {
+		setter(val)
+	}
+
+	// Then setting the generic hundred-level headers
+	d := fmt.Sprintf("%dxx", statusCode/100)
+	if val, ok := sch[d]; ok {
+		setter(val)
+	}
+
+	// Finally setting the status-specific headers
+	if val, ok := sch[strconv.Itoa(statusCode)]; ok {
+		setter(val)
+	}
+}
+
+type uiRequestFunc func(*http.Request) bool
+
+// wrapCustomHeadersHandler wraps the handler to pass a custom ResponseWriter struct to all
+// later wrappers and handlers to assign custom headers by status code. This wrapper must
+// be the outermost wrapper to function correctly.
+func WrapCustomHeadersHandler(h http.Handler, config *ListenerConfig, isUiRequest uiRequestFunc) http.Handler {
+	// TODO: maybe we should perform some preparsing here on the headers? check for duplicates,
+	// headers that aren't allowed, etc. could also update that map to actually be int -> str
+	// rather than str -> str which requires converting status to strings, and may be slower
+
+	uiHeaders := config.CustomUiResponseHeaders
+	apiHeaders := config.CustomApiResponseHeaders
+
+	// TODO: we should also set the default headers here. whether or not they are stored in
+	// consts/etc is another thing
+	// NOTE: this is for boundary specific things. universal things would go in go-secure-stdlib
+
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		// this function is extremely generic as all we want to do is wrap the http.ResponseWriter
+		// in our own ResponseWriter above, which will then perform all the logic we actually want
+
+		var headers map[string]map[string]string
+
+		if isUiRequest(req) {
+			headers = uiHeaders
+		} else {
+			headers = apiHeaders
+		}
+
+		wrappedWriter := &ResponseWriter{
+			wrapped: w,
+			headers: headers,
+		}
+		h.ServeHTTP(wrappedWriter, req)
+	})
+}

--- a/listenerutil/handler.go
+++ b/listenerutil/handler.go
@@ -10,7 +10,7 @@ type ResponseWriter struct {
 	// headers[status][header name] = header value
 	// this map also contains values for hundred-level values in the format 1: "1xx", 2: "2xx", etc
 	// defaults are set to 0
-	headers       map[int]map[string][]string
+	headers       map[int]http.Header
 	headerWritten bool
 }
 
@@ -85,7 +85,7 @@ func WrapCustomHeadersHandler(h http.Handler, config *ListenerConfig, isUiReques
 		// this function is extremely generic as all we want to do is wrap the http.ResponseWriter
 		// in our own ResponseWriter above, which will then perform all the logic we actually want
 
-		var headers map[int]map[string][]string
+		var headers map[int]http.Header
 
 		if isUiRequest(req) {
 			headers = uiHeaders

--- a/listenerutil/handler.go
+++ b/listenerutil/handler.go
@@ -10,7 +10,7 @@ type ResponseWriter struct {
 	// headers[status][header name] = header value
 	// this map also contains values for hundred-level values in the format 1: "1xx", 2: "2xx", etc
 	// defaults are set to 0
-	headers       map[int]map[string]string
+	headers       map[int]map[string][]string
 	headerWritten bool
 }
 
@@ -46,9 +46,12 @@ func (w *ResponseWriter) setCustomResponseHeaders(statusCode int) {
 	}
 
 	// Setter function to set headers
-	setter := func(headerMap map[string]string) {
-		for header, value := range headerMap {
-			w.Header().Set(header, value)
+	setter := func(headerMap map[string][]string) {
+		for header, values := range headerMap {
+			w.Header().Del(header)
+			for _, value := range values {
+				w.Header().Add(header, value)
+			}
 		}
 	}
 
@@ -85,7 +88,7 @@ func WrapCustomHeadersHandler(h http.Handler, config *ListenerConfig, isUiReques
 		// this function is extremely generic as all we want to do is wrap the http.ResponseWriter
 		// in our own ResponseWriter above, which will then perform all the logic we actually want
 
-		var headers map[int]map[string]string
+		var headers map[int]map[string][]string
 
 		if isUiRequest(req) {
 			headers = uiHeaders

--- a/listenerutil/handler.go
+++ b/listenerutil/handler.go
@@ -101,5 +101,9 @@ func WrapCustomHeadersHandler(h http.Handler, config *ListenerConfig, isUiReques
 			headers: headers,
 		}
 		h.ServeHTTP(wrappedWriter, req)
+
+		if !wrappedWriter.headerWritten {
+			wrappedWriter.WriteHeader(http.StatusOK)
+		}
 	})
 }

--- a/listenerutil/handler.go
+++ b/listenerutil/handler.go
@@ -1,9 +1,7 @@
 package listenerutil
 
 import (
-	"fmt"
 	"net/http"
-	"strconv"
 )
 
 type ResponseWriter struct {
@@ -75,57 +73,12 @@ type uiRequestFunc func(*http.Request) bool
 // WrapCustomHeadersHandler wraps the handler to pass a custom ResponseWriter struct to all
 // later wrappers and handlers to assign custom headers by status code. This wrapper must
 // be the outermost wrapper to function correctly.
-func WrapCustomHeadersHandler(h http.Handler, config *ListenerConfig, isUiRequest uiRequestFunc) (http.Handler, error) {
+func WrapCustomHeadersHandler(h http.Handler, config *ListenerConfig, isUiRequest uiRequestFunc) http.Handler {
 	// TODO: maybe we should perform some preparsing here on the headers? check for duplicates,
 	// headers that aren't allowed, etc.
 
-	// Perform some basic parsing to convert status codes from strings to int to avoid costly string
-	// comparisons for every request.
-	uiHeaders := map[int]map[string]string{}
-
-	for status, headers := range config.CustomUiResponseHeaders {
-		if status == "default" {
-			uiHeaders[0] = headers
-			continue
-		}
-
-		intStatus, err := strconv.Atoi(status)
-		if err != nil {
-			if _, err = fmt.Sscanf(status, "%dxx", &intStatus); err != nil {
-				return nil, fmt.Errorf("status does not match expected format. should be a valid status code or formatted \"%%dxx\". was: %s", status)
-			}
-			if intStatus > 5 || intStatus < 1 {
-				return nil, fmt.Errorf("status is not within valid range, must be between 1xx and 5xx. was: %s", status)
-			}
-		}
-		if intStatus >= 600 || intStatus < 100 {
-			return nil, fmt.Errorf("status is not within valid range, must be between 100 and 599. was: %s", status)
-		}
-		uiHeaders[intStatus] = headers
-	}
-
-	apiHeaders := map[int]map[string]string{}
-
-	for status, headers := range config.CustomApiResponseHeaders {
-		if status == "default" {
-			apiHeaders[0] = headers
-			continue
-		}
-
-		intStatus, err := strconv.Atoi(status)
-		if err != nil {
-			if _, err = fmt.Sscanf(status, "%dxx", &intStatus); err != nil {
-				return nil, fmt.Errorf("status does not match expected format. should be a valid status code or formatted \"%%dxx\". was: %s", status)
-			}
-			if intStatus > 5 || intStatus < 1 {
-				return nil, fmt.Errorf("status is not within valid range, must be between 1xx and 5xx. was: %s", status)
-			}
-		}
-		if intStatus >= 600 || intStatus < 100 {
-			return nil, fmt.Errorf("status is not within valid range, must be between 100 and 599. was: %s", status)
-		}
-		apiHeaders[intStatus] = headers
-	}
+	uiHeaders := config.CustomUiResponseHeaders
+	apiHeaders := config.CustomApiResponseHeaders
 
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		// this function is extremely generic as all we want to do is wrap the http.ResponseWriter
@@ -144,5 +97,5 @@ func WrapCustomHeadersHandler(h http.Handler, config *ListenerConfig, isUiReques
 			headers: headers,
 		}
 		h.ServeHTTP(wrappedWriter, req)
-	}), nil
+	})
 }

--- a/listenerutil/handler.go
+++ b/listenerutil/handler.go
@@ -78,9 +78,6 @@ type uiRequestFunc func(*http.Request) bool
 // later wrappers and handlers to assign custom headers by status code. This wrapper must
 // be the outermost wrapper to function correctly.
 func WrapCustomHeadersHandler(h http.Handler, config *ListenerConfig, isUiRequest uiRequestFunc) http.Handler {
-	// TODO: maybe we should perform some preparsing here on the headers? check for duplicates,
-	// headers that aren't allowed, etc.
-
 	uiHeaders := config.CustomUiResponseHeaders
 	apiHeaders := config.CustomApiResponseHeaders
 

--- a/listenerutil/handler_test.go
+++ b/listenerutil/handler_test.go
@@ -1,0 +1,230 @@
+package listenerutil
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// type uiRequestFunc func(*http.Request) bool
+
+func TestCustomHeadersWrapper(t *testing.T) {
+	listenerConfig := &ListenerConfig{
+		Type: "tcp",
+		CustomApiResponseHeaders: map[int]map[string]string{
+			0: {
+				"Test":                      "default value; default value 2",
+				"Content-Security-Policy":   "default-src 'none'",
+				"X-Content-Type-Options":    "nosniff",
+				"Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+				"Cache-Control":             "no-store",
+			},
+			200: {
+				"Test": "200 value",
+			},
+			2: {
+				"Test": "2xx value",
+			},
+			401: {
+				"Test": "401 value",
+			},
+			4: {
+				"Test": "4xx value",
+			},
+		},
+		CustomUiResponseHeaders: map[int]map[string]string{
+			0: {
+				"Test":                      "ui default value",
+				"Content-Security-Policy":   "default-src 'none'; script-src 'self'; frame-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:*; style-src 'self'; media-src 'self'; manifest-src 'self'; style-src-attr 'self'; frame-ancestors 'self'",
+				"X-Content-Type-Options":    "nosniff",
+				"Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+				"Cache-Control":             "max-age=604800",
+			},
+			200: {
+				"Test": "ui 200 value",
+			},
+			2: {
+				"Test": "ui 2xx value",
+			},
+			401: {
+				"Test": "ui 401 value",
+			},
+			4: {
+				"Test": "ui 4xx value",
+			},
+		},
+	}
+
+	uiRequest := func(*http.Request) bool {
+		return true
+	}
+	apiRequest := func(*http.Request) bool {
+		return false
+	}
+
+	tests := []struct {
+		name        string
+		config      *ListenerConfig
+		handler     http.Handler
+		expHeaders  map[string]string
+		expStatus   int
+		wrapperFunc uiRequestFunc
+	}{
+		{
+			name:   "200 api response",
+			config: listenerConfig,
+			handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.Write([]byte("response"))
+			}),
+			expHeaders: map[string]string{
+				"Test":                      "200 value",
+				"Content-Security-Policy":   "default-src 'none'",
+				"X-Content-Type-Options":    "nosniff",
+				"Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+				"Cache-Control":             "no-store",
+			},
+			expStatus:   200,
+			wrapperFunc: apiRequest,
+		},
+		{
+			name:   "300 api response",
+			config: listenerConfig,
+			handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.WriteHeader(300)
+				w.Write([]byte("response"))
+			}),
+			expHeaders: map[string]string{
+				"Test":                      "default value; default value 2",
+				"Content-Security-Policy":   "default-src 'none'",
+				"X-Content-Type-Options":    "nosniff",
+				"Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+				"Cache-Control":             "no-store",
+			},
+			expStatus:   300,
+			wrapperFunc: apiRequest,
+		},
+		{
+			name:   "400 api response",
+			config: listenerConfig,
+			handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.WriteHeader(400)
+				w.Write([]byte("response"))
+			}),
+			expHeaders: map[string]string{
+				"Test":                      "4xx value",
+				"Content-Security-Policy":   "default-src 'none'",
+				"X-Content-Type-Options":    "nosniff",
+				"Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+				"Cache-Control":             "no-store",
+			},
+			expStatus:   400,
+			wrapperFunc: apiRequest,
+		},
+		{
+			name:   "401 api response",
+			config: listenerConfig,
+			handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.WriteHeader(401)
+				w.Write([]byte("response"))
+			}),
+			expHeaders: map[string]string{
+				"Test":                      "401 value",
+				"Content-Security-Policy":   "default-src 'none'",
+				"X-Content-Type-Options":    "nosniff",
+				"Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+				"Cache-Control":             "no-store",
+			},
+			expStatus:   401,
+			wrapperFunc: apiRequest,
+		},
+		// butts
+		{
+			name:   "200 ui response",
+			config: listenerConfig,
+			handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.Write([]byte("response"))
+			}),
+			expHeaders: map[string]string{
+				"Test":                      "ui 200 value",
+				"Content-Security-Policy":   "default-src 'none'; script-src 'self'; frame-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:*; style-src 'self'; media-src 'self'; manifest-src 'self'; style-src-attr 'self'; frame-ancestors 'self'",
+				"X-Content-Type-Options":    "nosniff",
+				"Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+				"Cache-Control":             "max-age=604800",
+			},
+			expStatus:   200,
+			wrapperFunc: uiRequest,
+		},
+		{
+			name:   "300 api response",
+			config: listenerConfig,
+			handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.WriteHeader(300)
+				w.Write([]byte("response"))
+			}),
+			expHeaders: map[string]string{
+				"Test":                      "ui default value",
+				"Content-Security-Policy":   "default-src 'none'; script-src 'self'; frame-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:*; style-src 'self'; media-src 'self'; manifest-src 'self'; style-src-attr 'self'; frame-ancestors 'self'",
+				"X-Content-Type-Options":    "nosniff",
+				"Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+				"Cache-Control":             "max-age=604800",
+			},
+			expStatus:   300,
+			wrapperFunc: uiRequest,
+		},
+		{
+			name:   "400 api response",
+			config: listenerConfig,
+			handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.WriteHeader(400)
+				w.Write([]byte("response"))
+			}),
+			expHeaders: map[string]string{
+				"Test":                      "ui 4xx value",
+				"Content-Security-Policy":   "default-src 'none'; script-src 'self'; frame-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:*; style-src 'self'; media-src 'self'; manifest-src 'self'; style-src-attr 'self'; frame-ancestors 'self'",
+				"X-Content-Type-Options":    "nosniff",
+				"Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+				"Cache-Control":             "max-age=604800",
+			},
+			expStatus:   400,
+			wrapperFunc: uiRequest,
+		},
+		{
+			name:   "401 api response",
+			config: listenerConfig,
+			handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.WriteHeader(401)
+				w.Write([]byte("response"))
+			}),
+			expHeaders: map[string]string{
+				"Test":                      "ui 401 value",
+				"Content-Security-Policy":   "default-src 'none'; script-src 'self'; frame-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:*; style-src 'self'; media-src 'self'; manifest-src 'self'; style-src-attr 'self'; frame-ancestors 'self'",
+				"X-Content-Type-Options":    "nosniff",
+				"Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+				"Cache-Control":             "max-age=604800",
+			},
+			expStatus:   401,
+			wrapperFunc: uiRequest,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			wrappedHandler := WrapCustomHeadersHandler(tt.handler, tt.config, tt.wrapperFunc)
+
+			r := httptest.NewRequest("GET", "http://localhost:9200/", nil)
+			w := httptest.NewRecorder()
+			wrappedHandler.ServeHTTP(w, r)
+
+			resp := w.Result()
+			fmt.Printf("response: %#v", resp)
+			assert.Equal(t, tt.expStatus, resp.StatusCode)
+
+			for header, expected := range tt.expHeaders {
+				assert.Equal(t, expected, resp.Header.Get(header))
+			}
+		})
+	}
+}

--- a/listenerutil/handler_test.go
+++ b/listenerutil/handler_test.go
@@ -14,46 +14,46 @@ import (
 func TestCustomHeadersWrapper(t *testing.T) {
 	listenerConfig := &ListenerConfig{
 		Type: "tcp",
-		CustomApiResponseHeaders: map[int]map[string]string{
+		CustomApiResponseHeaders: map[int]map[string][]string{
 			0: {
-				"Test":                      "default value; default value 2",
-				"Content-Security-Policy":   "default-src 'none'",
-				"X-Content-Type-Options":    "nosniff",
-				"Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-				"Cache-Control":             "no-store",
+				"Test":                      {"default value", "default value 2"},
+				"Content-Security-Policy":   {"default-src 'none'"},
+				"X-Content-Type-Options":    {"nosniff"},
+				"Strict-Transport-Security": {"max-age=31536000", "includeSubDomains"},
+				"Cache-Control":             {"no-store"},
 			},
 			200: {
-				"Test": "200 value",
+				"Test": {"200 value"},
 			},
 			2: {
-				"Test": "2xx value",
+				"Test": {"2xx value"},
 			},
 			401: {
-				"Test": "401 value",
+				"Test": {"401 value"},
 			},
 			4: {
-				"Test": "4xx value",
+				"Test": {"4xx value"},
 			},
 		},
-		CustomUiResponseHeaders: map[int]map[string]string{
+		CustomUiResponseHeaders: map[int]map[string][]string{
 			0: {
-				"Test":                      "ui default value",
-				"Content-Security-Policy":   "default-src 'none'; script-src 'self'; frame-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:*; style-src 'self'; media-src 'self'; manifest-src 'self'; style-src-attr 'self'; frame-ancestors 'self'",
-				"X-Content-Type-Options":    "nosniff",
-				"Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-				"Cache-Control":             "max-age=604800",
+				"Test":                      {"ui default value"},
+				"Content-Security-Policy":   {"default-src 'none'; script-src 'self'; frame-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:*; style-src 'self'; media-src 'self'; manifest-src 'self'; style-src-attr 'self'; frame-ancestors 'self'"},
+				"X-Content-Type-Options":    {"nosniff"},
+				"Strict-Transport-Security": {"max-age=31536000; includeSubDomains"},
+				"Cache-Control":             {"max-age=604800"},
 			},
 			200: {
-				"Test": "ui 200 value",
+				"Test": {"ui 200 value"},
 			},
 			2: {
-				"Test": "ui 2xx value",
+				"Test": {"ui 2xx value"},
 			},
 			401: {
-				"Test": "ui 401 value",
+				"Test": {"ui 401 value"},
 			},
 			4: {
-				"Test": "ui 4xx value",
+				"Test": {"ui 4xx value"},
 			},
 		},
 	}

--- a/listenerutil/handler_test.go
+++ b/listenerutil/handler_test.go
@@ -12,7 +12,7 @@ import (
 func TestCustomHeadersWrapper(t *testing.T) {
 	listenerConfig := &ListenerConfig{
 		Type: "tcp",
-		CustomApiResponseHeaders: map[int]map[string][]string{
+		CustomApiResponseHeaders: map[int]http.Header{
 			0: {
 				"Test":                      {"default value", "default value 2"},
 				"Content-Security-Policy":   {"default-src 'none'"},
@@ -33,7 +33,7 @@ func TestCustomHeadersWrapper(t *testing.T) {
 				"Test": {"4xx value"},
 			},
 		},
-		CustomUiResponseHeaders: map[int]map[string][]string{
+		CustomUiResponseHeaders: map[int]http.Header{
 			0: {
 				"Test":                      {"ui default value"},
 				"Content-Security-Policy":   {"default-src 'none'; script-src 'self'; frame-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:*; style-src 'self'; media-src 'self'; manifest-src 'self'; style-src-attr 'self'; frame-ancestors 'self'"},

--- a/listenerutil/handler_test.go
+++ b/listenerutil/handler_test.go
@@ -1,15 +1,13 @@
 package listenerutil
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 )
-
-// type uiRequestFunc func(*http.Request) bool
 
 func TestCustomHeadersWrapper(t *testing.T) {
 	listenerConfig := &ListenerConfig{
@@ -19,7 +17,7 @@ func TestCustomHeadersWrapper(t *testing.T) {
 				"Test":                      {"default value", "default value 2"},
 				"Content-Security-Policy":   {"default-src 'none'"},
 				"X-Content-Type-Options":    {"nosniff"},
-				"Strict-Transport-Security": {"max-age=31536000", "includeSubDomains"},
+				"Strict-Transport-Security": {"max-age=31536000; includeSubDomains"},
 				"Cache-Control":             {"no-store"},
 			},
 			200: {
@@ -69,7 +67,7 @@ func TestCustomHeadersWrapper(t *testing.T) {
 		name        string
 		config      *ListenerConfig
 		handler     http.Handler
-		expHeaders  map[string]string
+		expHeaders  map[string][]string
 		expStatus   int
 		wrapperFunc uiRequestFunc
 	}{
@@ -79,12 +77,12 @@ func TestCustomHeadersWrapper(t *testing.T) {
 			handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 				w.Write([]byte("response"))
 			}),
-			expHeaders: map[string]string{
-				"Test":                      "200 value",
-				"Content-Security-Policy":   "default-src 'none'",
-				"X-Content-Type-Options":    "nosniff",
-				"Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-				"Cache-Control":             "no-store",
+			expHeaders: map[string][]string{
+				"Test":                      {"200 value"},
+				"Content-Security-Policy":   {"default-src 'none'"},
+				"X-Content-Type-Options":    {"nosniff"},
+				"Strict-Transport-Security": {"max-age=31536000; includeSubDomains"},
+				"Cache-Control":             {"no-store"},
 			},
 			expStatus:   200,
 			wrapperFunc: apiRequest,
@@ -96,12 +94,12 @@ func TestCustomHeadersWrapper(t *testing.T) {
 				w.WriteHeader(300)
 				w.Write([]byte("response"))
 			}),
-			expHeaders: map[string]string{
-				"Test":                      "default value; default value 2",
-				"Content-Security-Policy":   "default-src 'none'",
-				"X-Content-Type-Options":    "nosniff",
-				"Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-				"Cache-Control":             "no-store",
+			expHeaders: map[string][]string{
+				"Test":                      {"default value", "default value 2"},
+				"Content-Security-Policy":   {"default-src 'none'"},
+				"X-Content-Type-Options":    {"nosniff"},
+				"Strict-Transport-Security": {"max-age=31536000; includeSubDomains"},
+				"Cache-Control":             {"no-store"},
 			},
 			expStatus:   300,
 			wrapperFunc: apiRequest,
@@ -113,12 +111,12 @@ func TestCustomHeadersWrapper(t *testing.T) {
 				w.WriteHeader(400)
 				w.Write([]byte("response"))
 			}),
-			expHeaders: map[string]string{
-				"Test":                      "4xx value",
-				"Content-Security-Policy":   "default-src 'none'",
-				"X-Content-Type-Options":    "nosniff",
-				"Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-				"Cache-Control":             "no-store",
+			expHeaders: map[string][]string{
+				"Test":                      {"4xx value"},
+				"Content-Security-Policy":   {"default-src 'none'"},
+				"X-Content-Type-Options":    {"nosniff"},
+				"Strict-Transport-Security": {"max-age=31536000; includeSubDomains"},
+				"Cache-Control":             {"no-store"},
 			},
 			expStatus:   400,
 			wrapperFunc: apiRequest,
@@ -130,12 +128,12 @@ func TestCustomHeadersWrapper(t *testing.T) {
 				w.WriteHeader(401)
 				w.Write([]byte("response"))
 			}),
-			expHeaders: map[string]string{
-				"Test":                      "401 value",
-				"Content-Security-Policy":   "default-src 'none'",
-				"X-Content-Type-Options":    "nosniff",
-				"Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-				"Cache-Control":             "no-store",
+			expHeaders: map[string][]string{
+				"Test":                      {"401 value"},
+				"Content-Security-Policy":   {"default-src 'none'"},
+				"X-Content-Type-Options":    {"nosniff"},
+				"Strict-Transport-Security": {"max-age=31536000; includeSubDomains"},
+				"Cache-Control":             {"no-store"},
 			},
 			expStatus:   401,
 			wrapperFunc: apiRequest,
@@ -147,12 +145,12 @@ func TestCustomHeadersWrapper(t *testing.T) {
 			handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 				w.Write([]byte("response"))
 			}),
-			expHeaders: map[string]string{
-				"Test":                      "ui 200 value",
-				"Content-Security-Policy":   "default-src 'none'; script-src 'self'; frame-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:*; style-src 'self'; media-src 'self'; manifest-src 'self'; style-src-attr 'self'; frame-ancestors 'self'",
-				"X-Content-Type-Options":    "nosniff",
-				"Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-				"Cache-Control":             "max-age=604800",
+			expHeaders: map[string][]string{
+				"Test":                      {"ui 200 value"},
+				"Content-Security-Policy":   {"default-src 'none'; script-src 'self'; frame-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:*; style-src 'self'; media-src 'self'; manifest-src 'self'; style-src-attr 'self'; frame-ancestors 'self'"},
+				"X-Content-Type-Options":    {"nosniff"},
+				"Strict-Transport-Security": {"max-age=31536000; includeSubDomains"},
+				"Cache-Control":             {"max-age=604800"},
 			},
 			expStatus:   200,
 			wrapperFunc: uiRequest,
@@ -164,12 +162,12 @@ func TestCustomHeadersWrapper(t *testing.T) {
 				w.WriteHeader(300)
 				w.Write([]byte("response"))
 			}),
-			expHeaders: map[string]string{
-				"Test":                      "ui default value",
-				"Content-Security-Policy":   "default-src 'none'; script-src 'self'; frame-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:*; style-src 'self'; media-src 'self'; manifest-src 'self'; style-src-attr 'self'; frame-ancestors 'self'",
-				"X-Content-Type-Options":    "nosniff",
-				"Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-				"Cache-Control":             "max-age=604800",
+			expHeaders: map[string][]string{
+				"Test":                      {"ui default value"},
+				"Content-Security-Policy":   {"default-src 'none'; script-src 'self'; frame-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:*; style-src 'self'; media-src 'self'; manifest-src 'self'; style-src-attr 'self'; frame-ancestors 'self'"},
+				"X-Content-Type-Options":    {"nosniff"},
+				"Strict-Transport-Security": {"max-age=31536000; includeSubDomains"},
+				"Cache-Control":             {"max-age=604800"},
 			},
 			expStatus:   300,
 			wrapperFunc: uiRequest,
@@ -181,12 +179,12 @@ func TestCustomHeadersWrapper(t *testing.T) {
 				w.WriteHeader(400)
 				w.Write([]byte("response"))
 			}),
-			expHeaders: map[string]string{
-				"Test":                      "ui 4xx value",
-				"Content-Security-Policy":   "default-src 'none'; script-src 'self'; frame-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:*; style-src 'self'; media-src 'self'; manifest-src 'self'; style-src-attr 'self'; frame-ancestors 'self'",
-				"X-Content-Type-Options":    "nosniff",
-				"Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-				"Cache-Control":             "max-age=604800",
+			expHeaders: map[string][]string{
+				"Test":                      {"ui 4xx value"},
+				"Content-Security-Policy":   {"default-src 'none'; script-src 'self'; frame-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:*; style-src 'self'; media-src 'self'; manifest-src 'self'; style-src-attr 'self'; frame-ancestors 'self'"},
+				"X-Content-Type-Options":    {"nosniff"},
+				"Strict-Transport-Security": {"max-age=31536000; includeSubDomains"},
+				"Cache-Control":             {"max-age=604800"},
 			},
 			expStatus:   400,
 			wrapperFunc: uiRequest,
@@ -198,20 +196,36 @@ func TestCustomHeadersWrapper(t *testing.T) {
 				w.WriteHeader(401)
 				w.Write([]byte("response"))
 			}),
-			expHeaders: map[string]string{
-				"Test":                      "ui 401 value",
-				"Content-Security-Policy":   "default-src 'none'; script-src 'self'; frame-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:*; style-src 'self'; media-src 'self'; manifest-src 'self'; style-src-attr 'self'; frame-ancestors 'self'",
-				"X-Content-Type-Options":    "nosniff",
-				"Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-				"Cache-Control":             "max-age=604800",
+			expHeaders: map[string][]string{
+				"Test":                      {"ui 401 value"},
+				"Content-Security-Policy":   {"default-src 'none'; script-src 'self'; frame-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:*; style-src 'self'; media-src 'self'; manifest-src 'self'; style-src-attr 'self'; frame-ancestors 'self'"},
+				"X-Content-Type-Options":    {"nosniff"},
+				"Strict-Transport-Security": {"max-age=31536000; includeSubDomains"},
+				"Cache-Control":             {"max-age=604800"},
 			},
 			expStatus:   401,
 			wrapperFunc: uiRequest,
 		},
+		{
+			name:   "empty response",
+			config: listenerConfig,
+			handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.Header().Add("Test2", "another value, ey")
+			}),
+			expHeaders: map[string][]string{
+				"Test":                      {"200 value"},
+				"Content-Security-Policy":   {"default-src 'none'"},
+				"X-Content-Type-Options":    {"nosniff"},
+				"Strict-Transport-Security": {"max-age=31536000; includeSubDomains"},
+				"Cache-Control":             {"no-store"},
+				"Test2":                     {"another value, ey"},
+			},
+			expStatus:   200,
+			wrapperFunc: apiRequest,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			wrappedHandler := WrapCustomHeadersHandler(tt.handler, tt.config, tt.wrapperFunc)
 
 			r := httptest.NewRequest("GET", "http://localhost:9200/", nil)
@@ -219,11 +233,10 @@ func TestCustomHeadersWrapper(t *testing.T) {
 			wrappedHandler.ServeHTTP(w, r)
 
 			resp := w.Result()
-			fmt.Printf("response: %#v", resp)
 			assert.Equal(t, tt.expStatus, resp.StatusCode)
 
 			for header, expected := range tt.expHeaders {
-				assert.Equal(t, expected, resp.Header.Get(header))
+				assert.Empty(t, cmp.Diff(expected, resp.Header.Values(header)))
 			}
 		})
 	}

--- a/listenerutil/listener.go
+++ b/listenerutil/listener.go
@@ -146,6 +146,7 @@ PASSPHRASECORRECT:
 				badCiphers = append(badCiphers, cipherStr)
 			}
 		}
+		// TODO: change this to not use a vault-specific error
 		if len(badCiphers) == len(l.TLSCipherSuites) {
 			ui.Warn(`WARNING! All cipher suites defined by 'tls_cipher_suites' are blacklisted by the
 HTTP/2 specification. HTTP/2 communication with TLS 1.2 will not work as intended

--- a/listenerutil/listener.go
+++ b/listenerutil/listener.go
@@ -85,7 +85,7 @@ func TLSConfig(
 	if err := cg.Reload(); err != nil {
 		// We try the key without a passphrase first and if we get an incorrect
 		// passphrase response, try again after prompting for a passphrase
-		if errors.As(err, &x509.IncorrectPasswordError) {
+		if errors.Is(err, x509.IncorrectPasswordError) {
 			var passphrase string
 			passphrase, err = ui.AskSecret(fmt.Sprintf("Enter passphrase for %s:", l.TLSKeyFile))
 			if err == nil {
@@ -146,11 +146,10 @@ PASSPHRASECORRECT:
 				badCiphers = append(badCiphers, cipherStr)
 			}
 		}
-		// TODO: change this to not use a vault-specific error
 		if len(badCiphers) == len(l.TLSCipherSuites) {
 			ui.Warn(`WARNING! All cipher suites defined by 'tls_cipher_suites' are blacklisted by the
 HTTP/2 specification. HTTP/2 communication with TLS 1.2 will not work as intended
-and Vault will be unavailable via the CLI.
+and the application may be unavailable.
 Please see https://tools.ietf.org/html/rfc7540#appendix-A for further information.`)
 		} else if len(badCiphers) > 0 {
 			ui.Warn(fmt.Sprintf(`WARNING! The following cipher suites defined by 'tls_cipher_suites' are

--- a/listenerutil/parse.go
+++ b/listenerutil/parse.go
@@ -444,14 +444,14 @@ func parseCustomResponseHeaders(responseHeaders interface{}, uiHeaders bool) (ma
 
 	customResponseHeader, ok := responseHeaders.([]map[string]interface{})
 	if !ok {
-		return nil, fmt.Errorf("response headers were not configured correctly. please make sure they're in a slice of maps")
+		return nil, fmt.Errorf("response headers were not configured correctly. Please make sure they're in a list of maps")
 	}
 
 	for _, crh := range customResponseHeader {
 		for statusCode, responseHeader := range crh {
 			headerValList, ok := responseHeader.([]map[string]interface{})
 			if !ok {
-				return nil, fmt.Errorf("response headers were not configured correctly. please make sure they're in a slice of maps")
+				return nil, fmt.Errorf("response headers were not configured correctly. Please make sure they're in a list of maps")
 			}
 
 			if !isValidStatusCode(statusCode) {
@@ -495,7 +495,7 @@ func parseCustomResponseHeaders(responseHeaders interface{}, uiHeaders bool) (ma
 	return h, nil
 }
 
-// isValidStatusCode checking for status codes outside the boundary
+// isValidStatusCode checks for status codes outside the allowed range
 func isValidStatusCode(sc string) bool {
 	if strutil.StrListContains(validCustomStatusCodeCollection, sc) {
 		return true

--- a/listenerutil/parse.go
+++ b/listenerutil/parse.go
@@ -414,15 +414,6 @@ func ParseSingleIPTemplate(ipTmpl string) (string, error) {
 	}
 }
 
-var validCustomStatusCodeCollection = []string{
-	"default",
-	"1xx",
-	"2xx",
-	"3xx",
-	"4xx",
-	"5xx",
-}
-
 const strictTransportSecurity = "max-age=31536000; includeSubDomains"
 const xContentTypeOptions = "nosniff"
 const cacheControl = "no-store"
@@ -436,7 +427,7 @@ const uiContentSecurityPolicy = "default-src 'none'; script-src 'self'; frame-sr
 // "Strict-Transport-Security", "X-Content-Type-Options", and "Content-Security-Policy".
 func parseCustomResponseHeaders(responseHeaders interface{}, uiHeaders bool) (map[int]map[string]string, error) {
 	h := make(map[int]map[string]string)
-	// if r is nil, we still should set the default custom headers
+	// if responseHeaders is nil, we still should set the default custom headers
 	if responseHeaders == nil {
 		h[0] = map[string]string{
 			"Strict-Transport-Security": strictTransportSecurity,

--- a/listenerutil/parse.go
+++ b/listenerutil/parse.go
@@ -3,6 +3,7 @@ package listenerutil
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"net/textproto"
 	"strconv"
 	"strings"
@@ -96,10 +97,10 @@ type ListenerConfig struct {
 	CorsAllowedHeadersRaw                    []string    `hcl:"cors_allowed_headers"`
 
 	// Custom Http response headers
-	CustomApiResponseHeaders    map[int]map[string][]string `hcl:"-"`
-	CustomApiResponseHeadersRaw interface{}                 `hcl:"custom_api_response_headers"`
-	CustomUiResponseHeaders     map[int]map[string][]string `hcl:"-"`
-	CustomUiResponseHeadersRaw  interface{}                 `hcl:"custom_ui_response_headers"`
+	CustomApiResponseHeaders    map[int]http.Header `hcl:"-"`
+	CustomApiResponseHeadersRaw interface{}         `hcl:"custom_api_response_headers"`
+	CustomUiResponseHeaders     map[int]http.Header `hcl:"-"`
+	CustomUiResponseHeadersRaw  interface{}         `hcl:"custom_ui_response_headers"`
 }
 
 func (l *ListenerConfig) GoString() string {
@@ -432,11 +433,11 @@ const cacheControl = "Cache-Control"
 // of status code to a map of header name and header values. It verifies the validity of the
 // status codes, and header values. It also adds the default headers values for "Cache-Control",
 // "Strict-Transport-Security", "X-Content-Type-Options", and "Content-Security-Policy".
-func parseCustomResponseHeaders(responseHeaders interface{}, uiHeaders bool) (map[int]map[string][]string, error) {
-	h := make(map[int]map[string][]string)
+func parseCustomResponseHeaders(responseHeaders interface{}, uiHeaders bool) (map[int]http.Header, error) {
+	h := make(map[int]http.Header)
 	// if responseHeaders is nil, we still should set the default custom headers
 	if responseHeaders == nil {
-		h[0] = map[string][]string{
+		h[0] = http.Header{
 			strictTransportSecurity: {defaultStrictTransportSecurityHeader},
 			xContentTypeOptions:     {defaultXContentTypeOptionsHeader},
 			cacheControl:            {defaultCacheControlHeader},

--- a/reloadutil/reload_test.go
+++ b/reloadutil/reload_test.go
@@ -62,7 +62,7 @@ opM24uvQT3Bc0UM0WNh3tdRFuboxDeBDh7PX/2RIoiaMuCCiRZ3O0A==
 	if err == nil {
 		t.Fatal("error expected")
 	}
-	if !errors.As(err, &x509.IncorrectPasswordError) {
+	if !errors.Is(err, x509.IncorrectPasswordError) {
 		t.Fatalf("expected incorrect password error, got %v", err)
 	}
 


### PR DESCRIPTION
adds two additional configuration settings to the `listener` config section:
`custom_api_response_headers` and `custom_ui_response_headers`

this update also adds `WrapCustomHeadersHandler` wrapper which includes all of the logic necessary to perform custom header injection automatically