### PR TITLE
Fix Default CSP img-src

### DIFF
--- a/configutil/config_test.go
+++ b/configutil/config_test.go
@@ -163,7 +163,7 @@ func TestParseConfig(t *testing.T) {
 						CustomUiResponseHeaders: map[int]http.Header{
 							0: {
 								"Test":                      {"ui default value"},
-								"Content-Security-Policy":   {"default-src 'none'; script-src 'self'; frame-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:*; style-src 'self'; media-src 'self'; manifest-src 'self'; style-src-attr 'self'; frame-ancestors 'self'"},
+								"Content-Security-Policy":   {"default-src 'none'; script-src 'self'; frame-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:; style-src 'self'; media-src 'self'; manifest-src 'self'; style-src-attr 'self'; frame-ancestors 'self'"},
 								"X-Content-Type-Options":    {"nosniff"},
 								"Strict-Transport-Security": {"max-age=31536000; includeSubDomains"},
 								"Cache-Control":             {"max-age=604800"},

--- a/listenerutil/handler_test.go
+++ b/listenerutil/handler_test.go
@@ -36,7 +36,7 @@ func TestCustomHeadersWrapper(t *testing.T) {
 		CustomUiResponseHeaders: map[int]http.Header{
 			0: {
 				"Test":                      {"ui default value"},
-				"Content-Security-Policy":   {"default-src 'none'; script-src 'self'; frame-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:*; style-src 'self'; media-src 'self'; manifest-src 'self'; style-src-attr 'self'; frame-ancestors 'self'"},
+				"Content-Security-Policy":   {"default-src 'none'; script-src 'self'; frame-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:; style-src 'self'; media-src 'self'; manifest-src 'self'; style-src-attr 'self'; frame-ancestors 'self'"},
 				"X-Content-Type-Options":    {"nosniff"},
 				"Strict-Transport-Security": {"max-age=31536000; includeSubDomains"},
 				"Cache-Control":             {"max-age=604800"},
@@ -147,7 +147,7 @@ func TestCustomHeadersWrapper(t *testing.T) {
 			}),
 			expHeaders: map[string][]string{
 				"Test":                      {"ui 200 value"},
-				"Content-Security-Policy":   {"default-src 'none'; script-src 'self'; frame-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:*; style-src 'self'; media-src 'self'; manifest-src 'self'; style-src-attr 'self'; frame-ancestors 'self'"},
+				"Content-Security-Policy":   {"default-src 'none'; script-src 'self'; frame-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:; style-src 'self'; media-src 'self'; manifest-src 'self'; style-src-attr 'self'; frame-ancestors 'self'"},
 				"X-Content-Type-Options":    {"nosniff"},
 				"Strict-Transport-Security": {"max-age=31536000; includeSubDomains"},
 				"Cache-Control":             {"max-age=604800"},
@@ -164,7 +164,7 @@ func TestCustomHeadersWrapper(t *testing.T) {
 			}),
 			expHeaders: map[string][]string{
 				"Test":                      {"ui default value"},
-				"Content-Security-Policy":   {"default-src 'none'; script-src 'self'; frame-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:*; style-src 'self'; media-src 'self'; manifest-src 'self'; style-src-attr 'self'; frame-ancestors 'self'"},
+				"Content-Security-Policy":   {"default-src 'none'; script-src 'self'; frame-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:; style-src 'self'; media-src 'self'; manifest-src 'self'; style-src-attr 'self'; frame-ancestors 'self'"},
 				"X-Content-Type-Options":    {"nosniff"},
 				"Strict-Transport-Security": {"max-age=31536000; includeSubDomains"},
 				"Cache-Control":             {"max-age=604800"},
@@ -181,7 +181,7 @@ func TestCustomHeadersWrapper(t *testing.T) {
 			}),
 			expHeaders: map[string][]string{
 				"Test":                      {"ui 4xx value"},
-				"Content-Security-Policy":   {"default-src 'none'; script-src 'self'; frame-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:*; style-src 'self'; media-src 'self'; manifest-src 'self'; style-src-attr 'self'; frame-ancestors 'self'"},
+				"Content-Security-Policy":   {"default-src 'none'; script-src 'self'; frame-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:; style-src 'self'; media-src 'self'; manifest-src 'self'; style-src-attr 'self'; frame-ancestors 'self'"},
 				"X-Content-Type-Options":    {"nosniff"},
 				"Strict-Transport-Security": {"max-age=31536000; includeSubDomains"},
 				"Cache-Control":             {"max-age=604800"},
@@ -198,7 +198,7 @@ func TestCustomHeadersWrapper(t *testing.T) {
 			}),
 			expHeaders: map[string][]string{
 				"Test":                      {"ui 401 value"},
-				"Content-Security-Policy":   {"default-src 'none'; script-src 'self'; frame-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:*; style-src 'self'; media-src 'self'; manifest-src 'self'; style-src-attr 'self'; frame-ancestors 'self'"},
+				"Content-Security-Policy":   {"default-src 'none'; script-src 'self'; frame-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:; style-src 'self'; media-src 'self'; manifest-src 'self'; style-src-attr 'self'; frame-ancestors 'self'"},
 				"X-Content-Type-Options":    {"nosniff"},
 				"Strict-Transport-Security": {"max-age=31536000; includeSubDomains"},
 				"Cache-Control":             {"max-age=604800"},

--- a/listenerutil/parse.go
+++ b/listenerutil/parse.go
@@ -420,7 +420,7 @@ const defaultStrictTransportSecurityHeader = "max-age=31536000; includeSubDomain
 const defaultXContentTypeOptionsHeader = "nosniff"
 const defaultCacheControlHeader = "no-store"
 const defaultApiContentSecurityPolicyHeader = "default-src 'none'"
-const defaultUiContentSecurityPolicyHeader = "default-src 'none'; script-src 'self'; frame-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:*; style-src 'self'; media-src 'self'; manifest-src 'self'; style-src-attr 'self'; frame-ancestors 'self'"
+const defaultUiContentSecurityPolicyHeader = "default-src 'none'; script-src 'self'; frame-src 'self'; font-src 'self'; connect-src 'self'; img-src 'self' data:; style-src 'self'; media-src 'self'; manifest-src 'self'; style-src-attr 'self'; frame-ancestors 'self'"
 
 // Header names consts
 const contentSecurityPolicy = "Content-Security-Policy"


### PR DESCRIPTION
Replaces all instances of `data:*` with `data:` to correctly set the `img-src` policy of the default `content-security-policy`.

`data:*` does not correctly allow `data:image/png;base64,...` type inline images, but `data:` does