### PR TITLE
feat: support adding ec2-instance role provider

### DIFF
--- a/awsutil/go.mod
+++ b/awsutil/go.mod
@@ -8,10 +8,10 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-hclog v0.16.2
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/mattn/go-colorable v0.1.6 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.5.1
 	golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980 // indirect
-	gopkg.in/yaml.v2 v2.2.8 // indirect
 )

--- a/awsutil/go.sum
+++ b/awsutil/go.sum
@@ -16,8 +16,11 @@ github.com/hashicorp/go-hclog v0.16.2 h1:K4ev2ib4LdQETX5cSZBG0DVLk1jwGqSPXBjdah3
 github.com/hashicorp/go-hclog v0.16.2/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
-github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
 github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=

--- a/awsutil/options.go
+++ b/awsutil/options.go
@@ -40,6 +40,11 @@ type options struct {
 	withIamEndpoint            string
 	withMaxRetries             *int
 	withRegion                 string
+	withRoleArn                string
+	withRoleSessionName        string
+	withRoleExternalId         string
+	withRoleTags               map[string]string
+	withWebIdentityTokenFile   string
 	withHttpClient             *http.Client
 	withValidityCheckTimeout   time.Duration
 	withIAMAPIFunc             IAMAPIFunc
@@ -51,6 +56,57 @@ func getDefaultOptions() options {
 		withEnvironmentCredentials: true,
 		withSharedCredentials:      true,
 		withClientType:             "iam",
+	}
+}
+
+// WithRoleArn allows passing a role arn to use when
+// creating either a web identity role provider
+// or a ec2-instance role provider.
+func WithRoleArn(with string) Option {
+	return func(o *options) error {
+		o.withRoleArn = with
+		return nil
+	}
+}
+
+// WithRoleSessionName allows passing a session name to use when
+// creating either a web identity role provider
+// or a ec2-instance role provider.
+// If set, the RoleARN must be set.
+func WithRoleSessionName(with string) Option {
+	return func(o *options) error {
+		o.withRoleSessionName = with
+		return nil
+	}
+}
+
+// WithRoleExternalId allows passing a external id to use when
+// creating a ec2-instance role provider.
+// If not set, the role will be assumed in the same account.
+// If set, the RoleARN must be set.
+func WithRoleExternalId(with string) Option {
+	return func(o *options) error {
+		o.withRoleExternalId = with
+		return nil
+	}
+}
+
+// WithRoleTags allows passing tags to use when
+// creating a ec2-instance role provider.
+// If set, the RoleARN must be set.
+func WithRoleTags(with map[string]string) Option {
+	return func(o *options) error {
+		o.withRoleTags = with
+		return nil
+	}
+}
+
+// WithWebIdentityTokenFile allows passing a web identity token file to use for
+// the assumed role. If set, the RoleARN must be set.
+func WithWebIdentityTokenFile(with string) Option {
+	return func(o *options) error {
+		o.withWebIdentityTokenFile = with
+		return nil
 	}
 }
 

--- a/awsutil/options_test.go
+++ b/awsutil/options_test.go
@@ -128,4 +128,43 @@ func Test_GetOpts(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, opts.withSTSAPIFunc)
 	})
+	t.Run("withRoleArn", func(t *testing.T) {
+		opts, err := getOpts(WithRoleArn("foobar"))
+		require.NoError(t, err)
+		testOpts := getDefaultOptions()
+		testOpts.withRoleArn = "foobar"
+		assert.Equal(t, opts, testOpts)
+	})
+	t.Run("withRoleExternalId", func(t *testing.T) {
+		opts, err := getOpts(WithRoleExternalId("foobar"))
+		require.NoError(t, err)
+		testOpts := getDefaultOptions()
+		testOpts.withRoleExternalId = "foobar"
+		assert.Equal(t, opts, testOpts)
+	})
+	t.Run("withRoleSessionName", func(t *testing.T) {
+		opts, err := getOpts(WithRoleSessionName("foobar"))
+		require.NoError(t, err)
+		testOpts := getDefaultOptions()
+		testOpts.withRoleSessionName = "foobar"
+		assert.Equal(t, opts, testOpts)
+	})
+	t.Run("WithRoleTags", func(t *testing.T) {
+		opts, err := getOpts(WithRoleTags(map[string]string{
+			"foo": "bar",
+		}))
+		require.NoError(t, err)
+		testOpts := getDefaultOptions()
+		testOpts.withRoleTags = map[string]string{
+			"foo": "bar",
+		}
+		assert.Equal(t, opts, testOpts)
+	})
+	t.Run("WithWebIdentityTokenFile", func(t *testing.T) {
+		opts, err := getOpts(WithWebIdentityTokenFile("foo"))
+		require.NoError(t, err)
+		testOpts := getDefaultOptions()
+		testOpts.withWebIdentityTokenFile = "foo"
+		assert.Equal(t, opts, testOpts)
+	})
 }


### PR DESCRIPTION
## Summary

This PR enables the ability to add ec2-instance role providers to the credential chain for awsutil.

### Changes

- Added the following options to support ec2-instance role provider: WithRoleExternalId, WithRoleTags, WithWebIdentityTokenFile, WithRoleSessionName, WithRoleArn
- GenerateCredentialChain() will append a ec2-instance role provider to the provider chain when roleARN is not empty and WebIdentityTokenFile is empty. 