### PR TITLE
awsutil: add a mock ListAccessKeys pair

### DIFF
--- a/awsutil/mocks.go
+++ b/awsutil/mocks.go
@@ -22,6 +22,8 @@ type MockIAM struct {
 	CreateAccessKeyOutput *iam.CreateAccessKeyOutput
 	CreateAccessKeyError  error
 	DeleteAccessKeyError  error
+	ListAccessKeysOutput  *iam.ListAccessKeysOutput
+	ListAccessKeysError   error
 	GetUserOutput         *iam.GetUserOutput
 	GetUserError          error
 }
@@ -52,6 +54,22 @@ func WithCreateAccessKeyError(e error) MockIAMOption {
 func WithDeleteAccessKeyError(e error) MockIAMOption {
 	return func(m *MockIAM) error {
 		m.DeleteAccessKeyError = e
+		return nil
+	}
+}
+
+// WithListAccessKeysOutput sets the output for the ListAccessKeys method.
+func WithListAccessKeysOutput(o *iam.ListAccessKeysOutput) MockIAMOption {
+	return func(m *MockIAM) error {
+		m.ListAccessKeysOutput = o
+		return nil
+	}
+}
+
+// WithListAccessKeysError sets the error output for the ListAccessKeys method.
+func WithListAccessKeysError(e error) MockIAMOption {
+	return func(m *MockIAM) error {
+		m.ListAccessKeysError = e
 		return nil
 	}
 }
@@ -97,6 +115,14 @@ func (m *MockIAM) CreateAccessKey(*iam.CreateAccessKeyInput) (*iam.CreateAccessK
 
 func (m *MockIAM) DeleteAccessKey(*iam.DeleteAccessKeyInput) (*iam.DeleteAccessKeyOutput, error) {
 	return &iam.DeleteAccessKeyOutput{}, m.DeleteAccessKeyError
+}
+
+func (m *MockIAM) ListAccessKeys(*iam.ListAccessKeysInput) (*iam.ListAccessKeysOutput, error) {
+	if m.ListAccessKeysError != nil {
+		return nil, m.ListAccessKeysError
+	}
+
+	return m.ListAccessKeysOutput, nil
 }
 
 func (m *MockIAM) GetUser(*iam.GetUserInput) (*iam.GetUserOutput, error) {

--- a/awsutil/mocks_test.go
+++ b/awsutil/mocks_test.go
@@ -3,7 +3,7 @@ package awsutil
 import (
 	"errors"
 	"testing"
-
+	
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/sts"
@@ -18,6 +18,8 @@ func TestMockIAM(t *testing.T) {
 		expectedCreateAccessKeyOutput *iam.CreateAccessKeyOutput
 		expectedCreateAccessKeyError  error
 		expectedDeleteAccessKeyError  error
+		expectedListAccessKeysOutput  *iam.ListAccessKeysOutput
+		expectedListAccessKeysError   error
 		expectedGetUserOutput         *iam.GetUserOutput
 		expectedGetUserError          error
 	}{
@@ -42,6 +44,34 @@ func TestMockIAM(t *testing.T) {
 			name:                         "CreateAccessKeyError",
 			opts:                         []MockIAMOption{WithCreateAccessKeyError(errors.New("testerr"))},
 			expectedCreateAccessKeyError: errors.New("testerr"),
+		},
+		{
+			name: "ListAccessKeysOutput",
+			opts: []MockIAMOption{WithListAccessKeysOutput(
+				&iam.ListAccessKeysOutput{
+					AccessKeyMetadata: []*iam.AccessKeyMetadata{
+						{
+							AccessKeyId: aws.String("foobar"),
+							Status:      aws.String("bazqux"),
+							UserName:    aws.String("janedoe"),
+						},
+					},
+				},
+			)},
+			expectedListAccessKeysOutput: &iam.ListAccessKeysOutput{
+				AccessKeyMetadata: []*iam.AccessKeyMetadata{
+					{
+						AccessKeyId: aws.String("foobar"),
+						Status:      aws.String("bazqux"),
+						UserName:    aws.String("janedoe"),
+					},
+				},
+			},
+		},
+		{
+			name:                        "ListAccessKeysError",
+			opts:                        []MockIAMOption{WithListAccessKeysError(errors.New("testerr"))},
+			expectedListAccessKeysError: errors.New("testerr"),
 		},
 		{
 			name:                         "DeleteAccessKeyError",


### PR DESCRIPTION
Just a little bit of code to add a ListAccessKeys mock stub to awsutil.

Over in eco-applications we're adding some aws functionality and having this additional function available in the mock would be helpful, and it was mentioned that I should just go ahead and offer a PR for it.