### PR TITLE
awsutil: adding WebIdentityToken to CredentialsConfig{}

### DIFF
--- a/awsutil/generate_credentials.go
+++ b/awsutil/generate_credentials.go
@@ -403,10 +403,10 @@ func stsSigningResolver(service, region string, optFns ...func(*endpoints.Option
 // FetchTokenContents allows the use of the content of a token in the
 // WebIdentityProvider, instead of the path to a token. Useful with a
 // serviceaccount token requested directly from the EKS/K8s API, for example.
-type FetchTokenContents string
+type FetchTokenContents []byte
 
 var _ stscreds.TokenFetcher = (*FetchTokenContents)(nil)
 
 func (f FetchTokenContents) FetchToken(_ aws.Context) ([]byte, error) {
-	return []byte(f), nil
+	return f, nil
 }

--- a/awsutil/generate_credentials.go
+++ b/awsutil/generate_credentials.go
@@ -74,7 +74,7 @@ type CredentialsConfig struct {
 
 	// The web identity token (contents, not the file path) to use with the web
 	// identity token provider
-	WebIdentityToken []byte
+	WebIdentityToken string
 
 	// The http.Client to use, or nil for the client to use its default
 	HTTPClient *http.Client
@@ -239,7 +239,7 @@ func (c *CredentialsConfig) GenerateCredentialChain(opt ...Option) (*credentials
 				// Add the web identity role credential provider
 				providers = append(providers, webIdentityProvider)
 			}
-		} else if len(c.WebIdentityToken) > 0 {
+		} else if c.WebIdentityToken != "" {
 			c.log(hclog.Debug, "adding web identity provider with token", "roleARN", c.RoleARN)
 			sess, err := session.NewSession()
 			if err != nil {

--- a/awsutil/options.go
+++ b/awsutil/options.go
@@ -48,6 +48,7 @@ type options struct {
 	withRoleExternalId         string
 	withRoleTags               map[string]string
 	withWebIdentityTokenFile   string
+	withWebIdentityToken       []byte
 	withHttpClient             *http.Client
 	withValidityCheckTimeout   time.Duration
 	withIAMAPIFunc             IAMAPIFunc
@@ -109,6 +110,15 @@ func WithRoleTags(with map[string]string) Option {
 func WithWebIdentityTokenFile(with string) Option {
 	return func(o *options) error {
 		o.withWebIdentityTokenFile = with
+		return nil
+	}
+}
+
+// WithWebIdentityToken allows passing a web identity token to use for the
+// assumed role. If set, the RoleARN must be set.
+func WithWebIdentityToken(with []byte) Option {
+	return func(o *options) error {
+		o.withWebIdentityToken = with
 		return nil
 	}
 }

--- a/awsutil/options.go
+++ b/awsutil/options.go
@@ -48,7 +48,7 @@ type options struct {
 	withRoleExternalId         string
 	withRoleTags               map[string]string
 	withWebIdentityTokenFile   string
-	withWebIdentityToken       []byte
+	withWebIdentityToken       string
 	withHttpClient             *http.Client
 	withValidityCheckTimeout   time.Duration
 	withIAMAPIFunc             IAMAPIFunc
@@ -116,7 +116,7 @@ func WithWebIdentityTokenFile(with string) Option {
 
 // WithWebIdentityToken allows passing a web identity token to use for the
 // assumed role. If set, the RoleARN must be set.
-func WithWebIdentityToken(with []byte) Option {
+func WithWebIdentityToken(with string) Option {
 	return func(o *options) error {
 		o.withWebIdentityToken = with
 		return nil

--- a/awsutil/options.go
+++ b/awsutil/options.go
@@ -31,28 +31,29 @@ type Option func(*options) error
 
 // options = how options are represented
 type options struct {
-	withEnvironmentCredentials bool
-	withSharedCredentials      bool
-	withAwsSession             *session.Session
-	withClientType             string
-	withUsername               string
-	withAccessKey              string
-	withSecretKey              string
-	withLogger                 hclog.Logger
-	withStsEndpoint            string
-	withIamEndpoint            string
-	withMaxRetries             *int
-	withRegion                 string
-	withRoleArn                string
-	withRoleSessionName        string
-	withRoleExternalId         string
-	withRoleTags               map[string]string
-	withWebIdentityTokenFile   string
-	withWebIdentityToken       string
-	withHttpClient             *http.Client
-	withValidityCheckTimeout   time.Duration
-	withIAMAPIFunc             IAMAPIFunc
-	withSTSAPIFunc             STSAPIFunc
+	withEnvironmentCredentials  bool
+	withSharedCredentials       bool
+	withAwsSession              *session.Session
+	withClientType              string
+	withUsername                string
+	withAccessKey               string
+	withSecretKey               string
+	withLogger                  hclog.Logger
+	withStsEndpoint             string
+	withIamEndpoint             string
+	withMaxRetries              *int
+	withRegion                  string
+	withRoleArn                 string
+	withRoleSessionName         string
+	withRoleExternalId          string
+	withRoleTags                map[string]string
+	withWebIdentityTokenFile    string
+	withWebIdentityToken        string
+	withSkipWebIdentityValidity bool
+	withHttpClient              *http.Client
+	withValidityCheckTimeout    time.Duration
+	withIAMAPIFunc              IAMAPIFunc
+	withSTSAPIFunc              STSAPIFunc
 }
 
 func getDefaultOptions() options {
@@ -119,6 +120,15 @@ func WithWebIdentityTokenFile(with string) Option {
 func WithWebIdentityToken(with string) Option {
 	return func(o *options) error {
 		o.withWebIdentityToken = with
+		return nil
+	}
+}
+
+// WithSkipWebIdentityValidity allows controlling whether the validity check is
+// skipped for the web identity provider
+func WithSkipWebIdentityValidity(with bool) Option {
+	return func(o *options) error {
+		o.withSkipWebIdentityValidity = with
 		return nil
 	}
 }

--- a/awsutil/options_test.go
+++ b/awsutil/options_test.go
@@ -171,10 +171,10 @@ func Test_GetOpts(t *testing.T) {
 		assert.Equal(t, opts, testOpts)
 	})
 	t.Run("WithWebIdentityToken", func(t *testing.T) {
-		opts, err := getOpts(WithWebIdentityToken([]byte("foo")))
+		opts, err := getOpts(WithWebIdentityToken("foo"))
 		require.NoError(t, err)
 		testOpts := getDefaultOptions()
-		testOpts.withWebIdentityToken = []byte("foo")
+		testOpts.withWebIdentityToken = "foo"
 		assert.Equal(t, opts, testOpts)
 	})
 }

--- a/awsutil/options_test.go
+++ b/awsutil/options_test.go
@@ -177,4 +177,11 @@ func Test_GetOpts(t *testing.T) {
 		testOpts.withWebIdentityToken = "foo"
 		assert.Equal(t, opts, testOpts)
 	})
+	t.Run("WithSkipWebIdentityValidity", func(t *testing.T) {
+		opts, err := getOpts(WithSkipWebIdentityValidity(true))
+		require.NoError(t, err)
+		testOpts := getDefaultOptions()
+		testOpts.withSkipWebIdentityValidity = true
+		assert.Equal(t, opts, testOpts)
+	})
 }

--- a/awsutil/options_test.go
+++ b/awsutil/options_test.go
@@ -170,4 +170,11 @@ func Test_GetOpts(t *testing.T) {
 		testOpts.withWebIdentityTokenFile = "foo"
 		assert.Equal(t, opts, testOpts)
 	})
+	t.Run("WithWebIdentityToken", func(t *testing.T) {
+		opts, err := getOpts(WithWebIdentityToken([]byte("foo")))
+		require.NoError(t, err)
+		testOpts := getDefaultOptions()
+		testOpts.withWebIdentityToken = []byte("foo")
+		assert.Equal(t, opts, testOpts)
+	})
 }


### PR DESCRIPTION
Adds field `WebIdentityToken` to `CredentialsConfig{}`, along with a simple TokenFetcher to use the contents of a token in the WebIdentityProvider, instead of the path to a token file. Useful when working with a token requested directly for an EKS/k8s service account configured with IRSA, for example.

Used in https://github.com/hashicorp/vault-secrets-operator/pull/235