### PR TITLE
Ensure CI fails if tests fail

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,6 +31,7 @@ jobs:
       uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
         go-version-file: ${{ matrix.module }}/go.mod
+        cache-dependency-path: ${{ matrix.module }}/go.sum
 
     - name: Build
       run: cd ${{ matrix.module }} && go build ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,24 +1,44 @@
 name: Go
 
-on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+on: [push, workflow_dispatch]
 
 jobs:
-  build:
+  test:
+    strategy:
+      matrix:
+        module: ["awsutil",
+                  "base62",
+                  "configutil",
+                  "fileutil",
+                  "gatedwriter",
+                  "kv-builder",
+                  "listenerutil",
+                  "mlock",
+                  "nonceutil",
+                  "parseutil",
+                  "password",
+                  "pluginutil",
+                  "reloadutil",
+                  "strutil",
+                  "tlsutil"]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
     - name: Set up Go
-      uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
-        go-version: 1.17
+        go-version-file: ${{ matrix.module }}/go.mod
 
     - name: Build
-      run: find . -name go.mod -execdir go build ./... \;
+      run: cd ${{ matrix.module }} && go build ./...
 
     - name: Test
-      run: find . -name go.mod -execdir go test ./... \;
+      run: cd ${{ matrix.module }} && go test ./...
+
+  # Verify that every module folder is mentioned in this workflow file.
+  verify-ci:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+    - run: find * -name go.mod -print0 | xargs -0 dirname | xargs -I % grep % .github/workflows/go.yml > /dev/null

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -45,6 +45,6 @@ jobs:
     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
     - run: |
         if ! find * -name go.mod -print0 | xargs -0 dirname | xargs -I % grep % .github/workflows/go.yml > /dev/null; then
-          echo "Ensure every submodule is included in the matrix 'module' input above"
+          echo "Ensure every submodule is included in the matrix 'module' input in go.yml in the github workflows folder"
           exit 1
         fi

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,6 +5,7 @@ on: [push, workflow_dispatch]
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         module: ["awsutil",
                   "base62",

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,6 +4,7 @@ on: [push, workflow_dispatch]
 
 jobs:
   test:
+    name: ${{ matrix.module }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -43,4 +43,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-    - run: find * -name go.mod -print0 | xargs -0 dirname | xargs -I % grep % .github/workflows/go.yml > /dev/null
+    - run: |
+        if ! find * -name go.mod -print0 | xargs -0 dirname | xargs -I % grep % .github/workflows/go.yml > /dev/null; then
+          echo "Ensure every submodule is included in the matrix 'module' input above"
+          exit 1
+        fi

--- a/listenerutil/go.mod
+++ b/listenerutil/go.mod
@@ -1,11 +1,9 @@
 module github.com/hashicorp/go-secure-stdlib/listenerutil
 
-go 1.16
+go 1.17
 
 require (
-	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/google/go-cmp v0.5.9
-	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.7
 	github.com/hashicorp/go-secure-stdlib/reloadutil v0.1.1
@@ -14,8 +12,33 @@ require (
 	github.com/hashicorp/go-sockaddr v1.0.2
 	github.com/hashicorp/hcl v1.0.0
 	github.com/jefferai/isbadcipher v0.0.0-20190226160619-51d2077c035f
-	github.com/mattn/go-colorable v0.1.6 // indirect
 	github.com/mitchellh/cli v1.1.5
 	github.com/stretchr/testify v1.8.2
+)
+
+require (
+	github.com/Masterminds/goutils v1.1.1 // indirect
+	github.com/Masterminds/semver/v3 v3.1.1 // indirect
+	github.com/Masterminds/sprig/v3 v3.2.1 // indirect
+	github.com/armon/go-radix v1.0.0 // indirect
+	github.com/bgentry/speakeasy v0.1.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/fatih/color v1.7.0 // indirect
+	github.com/google/uuid v1.1.2 // indirect
+	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/huandu/xstrings v1.3.2 // indirect
+	github.com/imdario/mergo v0.3.11 // indirect
+	github.com/mattn/go-colorable v0.1.6 // indirect
+	github.com/mattn/go-isatty v0.0.12 // indirect
+	github.com/mitchellh/copystructure v1.0.0 // indirect
+	github.com/mitchellh/mapstructure v1.4.1 // indirect
+	github.com/mitchellh/reflectwalk v1.0.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/posener/complete v1.1.1 // indirect
+	github.com/ryanuber/go-glob v1.0.0 // indirect
+	github.com/shopspring/decimal v1.2.0 // indirect
+	github.com/spf13/cast v1.3.1 // indirect
+	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a // indirect
 	golang.org/x/sys v0.2.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/listenerutil/handler_go119.go
+++ b/listenerutil/handler_go119.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build !go1.20
+// +build !go1.20
 
 package listenerutil
 

--- a/listenerutil/handler_go120.go
+++ b/listenerutil/handler_go120.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build go1.20
+// +build go1.20
 
 package listenerutil
 

--- a/mlock/go.mod
+++ b/mlock/go.mod
@@ -1,5 +1,5 @@
 module github.com/hashicorp/go-secure-stdlib/mlock
 
-go 1.16
+go 1.17
 
 require golang.org/x/sys v0.7.0

--- a/parseutil/go.mod
+++ b/parseutil/go.mod
@@ -1,10 +1,17 @@
 module github.com/hashicorp/go-secure-stdlib/parseutil
 
-go 1.16
+go 1.17
 
 require (
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.1
 	github.com/hashicorp/go-sockaddr v1.0.2
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/stretchr/testify v1.7.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/ryanuber/go-glob v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/password/go.mod
+++ b/password/go.mod
@@ -1,8 +1,10 @@
 module github.com/hashicorp/go-secure-stdlib/password
 
-go 1.16
+go 1.17
 
 require (
 	golang.org/x/crypto v0.8.0
 	golang.org/x/sys v0.7.0
 )
+
+require golang.org/x/term v0.7.0 // indirect


### PR DESCRIPTION
Adding all of GitHub's suggested reviewers, but feel free to forward me on to other reviewers.

I noticed in #84 that the CI passes even if there are failures in the build and/or test, see here for an example on main: https://github.com/hashicorp/go-secure-stdlib/actions/runs/5602106840. See here for an example of the changes from this PR: https://github.com/hashicorp/go-secure-stdlib/actions/runs/5962737784

While we could probably fix it up with some bash wizardry, I also thought it seemed worthwhile to allow submodules to have their own Go version requirements, so I made a matrix strategy and also added an introspecting `verify-ci` step that ensures people don't forget to add their own module when they create new modules.

Finally, there are a few minor fixes, mostly where a module was actually depending on some Go features from a version ahead of its go.mod `go` directive. I've run `go mod tidy` in each module that required a `go` directive upgrade.

The build tags I added in `listenerutil` are not required from Go 1.18, but I thought it was less disruptive to add them than to bump the required Go version up further.