### PR TITLE
Set unix socket volume's bind mount propagation to private

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,6 +37,37 @@ jobs:
     - name: Build
       run: cd ${{ matrix.module }} && go build ./...
 
+    - name: Install gVisor
+      if: ${{ matrix.module == 'plugincontainer' }}
+      run: |
+        (
+          set -e
+          ARCH=$(uname -m)
+          URL=https://storage.googleapis.com/gvisor/releases/release/latest/${ARCH}
+          wget --quiet ${URL}/runsc ${URL}/runsc.sha512 \
+            ${URL}/containerd-shim-runsc-v1 ${URL}/containerd-shim-runsc-v1.sha512
+          sha512sum -c runsc.sha512 \
+            -c containerd-shim-runsc-v1.sha512
+          rm -f *.sha512
+          chmod a+rx runsc containerd-shim-runsc-v1
+          sudo mv runsc containerd-shim-runsc-v1 /usr/local/bin
+        )
+        cat | sudo tee /etc/docker/daemon.json <<EOF
+        {
+          "runtimes": {
+            "runsc": {
+              "path": "/usr/local/bin/runsc",
+              "runtimeArgs": [
+                "--host-uds=all",
+                "--host-fifo=open"
+              ]
+            }
+          }
+        }
+        EOF
+
+        sudo systemctl reload docker
+
     - name: Test
       run: cd ${{ matrix.module }} && go test ./...
 

--- a/plugincontainer/container_runner.go
+++ b/plugincontainer/container_runner.go
@@ -125,7 +125,9 @@ func NewContainerRunner(logger hclog.Logger, cmd *exec.Cmd, cfg *config.Containe
 				Target:   pluginSocketDir,
 				ReadOnly: false,
 				BindOptions: &mount.BindOptions{
-					Propagation:  mount.PropagationRShared,
+					// Private propagation, we don't need to replicate this mount.
+					// For details, see https://docs.docker.com/storage/bind-mounts/#configure-bind-propagation.
+					Propagation:  mount.PropagationPrivate,
 					NonRecursive: true,
 				},
 				Consistency: mount.ConsistencyDefault,

--- a/plugincontainer/container_runner_test.go
+++ b/plugincontainer/container_runner_test.go
@@ -128,6 +128,18 @@ func TestNewContainerRunner_config(t *testing.T) {
 }
 
 func TestExamplePlugin(t *testing.T) {
+	// Default docker runtime.
+	t.Run("runc", func(t *testing.T) {
+		testExamplePlugin_WithRuntime(t, "runc")
+	})
+
+	// gVisor runtime.
+	t.Run("runsc", func(t *testing.T) {
+		testExamplePlugin_WithRuntime(t, "runsc")
+	})
+}
+
+func testExamplePlugin_WithRuntime(t *testing.T, ociRuntime string) {
 	if runtime.GOOS != "linux" {
 		t.Skip("Only linux is supported for now")
 	}
@@ -174,7 +186,7 @@ func TestExamplePlugin(t *testing.T) {
 						Image:           tc.image,
 						SHA256:          tc.sha256,
 						UnixSocketGroup: fmt.Sprintf("%d", os.Getgid()),
-						Runtime:         "runsc",
+						Runtime:         ociRuntime,
 					}
 					return NewContainerRunner(logger, cmd, cfg, tmpDir)
 				},
@@ -280,7 +292,7 @@ func TestExamplePlugin(t *testing.T) {
 						Image:           tc.image,
 						SHA256:          tc.sha256,
 						UnixSocketGroup: fmt.Sprintf("%d", os.Getgid()),
-						Runtime:         "runsc",
+						Runtime:         ociRuntime,
 					}
 					return NewContainerRunner(logger, cmd, cfg, tmpDir)
 				},

--- a/plugincontainer/container_runner_test.go
+++ b/plugincontainer/container_runner_test.go
@@ -174,6 +174,7 @@ func TestExamplePlugin(t *testing.T) {
 						Image:           tc.image,
 						SHA256:          tc.sha256,
 						UnixSocketGroup: fmt.Sprintf("%d", os.Getgid()),
+						Runtime:         "runsc",
 					}
 					return NewContainerRunner(logger, cmd, cfg, tmpDir)
 				},
@@ -279,6 +280,7 @@ func TestExamplePlugin(t *testing.T) {
 						Image:           tc.image,
 						SHA256:          tc.sha256,
 						UnixSocketGroup: fmt.Sprintf("%d", os.Getgid()),
+						Runtime:         "runsc",
 					}
 					return NewContainerRunner(logger, cmd, cfg, tmpDir)
 				},


### PR DESCRIPTION
gVisor's runsc only supports "private" and "slave" modes, and we don't need any propagation anyway so just default to private. See here for some good documentation on the setting: https://docs.docker.com/storage/bind-mounts/#configure-bind-propagation

In particular:

> `private`: The mount is private. Sub-mounts within it are not exposed to replica mounts, and sub-mounts of replica mounts are not exposed to the original mount.


