### PR TITLE
plugincontainer: Drop all capabilities from plugin containers

### DIFF
--- a/plugincontainer/config.go
+++ b/plugincontainer/config.go
@@ -1,35 +1,37 @@
-package config
+package plugincontainer
 
 import (
 	"github.com/docker/docker/api/types/network"
 )
 
-// ContainerConfig is used to opt in to running plugins inside a container.
+// Config is used to opt in to running plugins inside a container.
 // Currently only compatible with Linux due to the requirements we have for
-// establising communication over a unix socket.
+// establishing communication over a unix socket.
 //
 // A temporary directory will be mounted into the container and both the host
 // and the plugin will create unix sockets that need to be writable from the
-// other side. To achieve this, there are broadly 3 runtime options (i.e. not
+// other side. To achieve this, there are broadly 2 runtime options (i.e. not
 // including build-time options):
 //
-//  1. Set UnixSocketGroup to tell go-plugin an additional group ID the container
-//     should run as, and that group will be set as the owning group of the socket.
-//  2. Set ContainerConfig.User to run the container with the same user ID as the
-//     client process. Equivalent to docker run --user="$(id -u):$(id -g)" ...
-//  3. Use a rootless container runtime, in which case the container process will
+//  1. Set up a uid or gid common to both the host and container processes, and
+//     ensure the unix socket is writable by that shared id. Set GroupAdd in this
+//     config and go-plugin ClientConfig's UnixSocketConfig Group with the same
+//     numeric gid to set up a common group. go-plugin will handle making all
+//     sockets writable by the gid.
+//  2. Use a rootless container runtime, in which case the container process will
 //     be run as the same unpriveleged user as the client.
-type ContainerConfig struct {
-	// UnixSocketGroup sets the group that should own the unix socket used for
-	// communication with the plugin. Can be a name or numeric gid.
-	//
-	// This is the least invasive option if you are not using a rootless container
-	// runtime. Alternatively, set User to a user name or UID:GID pair matching
-	// the client process.
-	UnixSocketGroup string
+type Config struct {
+	// GroupAdd sets an additional group that the container should run as. Should
+	// match the UnixSocketConfig Group passed to go-plugin. Needs to be set if
+	// the container runtime is not rootless.
+	GroupAdd int
+
+	// Container command/env
+	Entrypoint []string // If specified, replaces the container entrypoint.
+	Args       []string // If specified, replaces the container args.
+	Env        []string // A slice of x=y environment variables to add to the container.
 
 	// container.Config options
-	User           string            // User name or uid:gid to run the container as.
 	Image          string            // Image to run (without the tag), e.g. hashicorp/vault-plugin-auth-jwt
 	Tag            string            // Tag of the image to run, e.g. 0.16.0
 	SHA256         string            // SHA256 digest of the image. Can be a plain sha256 or prefixed with sha256:

--- a/plugincontainer/container_reattach.go
+++ b/plugincontainer/container_reattach.go
@@ -25,7 +25,7 @@ func ReattachFunc(logger hclog.Logger, id, hostSocketDir string) (runner.Attache
 		return nil, fmt.Errorf("container with ID %s not found: %w", id, err)
 	}
 
-	return &ContainerRunner{
+	return &containerRunner{
 		dockerClient:  client,
 		logger:        logger,
 		id:            id,

--- a/plugincontainer/container_runner.go
+++ b/plugincontainer/container_runner.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/docker/docker/api/types"
@@ -133,7 +134,7 @@ func (cfg *Config) NewContainerRunner(logger hclog.Logger, cmd *exec.Cmd, hostSo
 	}
 
 	if cfg.GroupAdd != 0 {
-		hostConfig.GroupAdd = append(hostConfig.GroupAdd, fmt.Sprintf("%d", cfg.GroupAdd))
+		hostConfig.GroupAdd = append(hostConfig.GroupAdd, strconv.Itoa(cfg.GroupAdd))
 	}
 
 	// Network config.

--- a/plugincontainer/container_runner_test.go
+++ b/plugincontainer/container_runner_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
@@ -17,8 +18,6 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin"
-	"github.com/hashicorp/go-plugin/runner"
-	"github.com/hashicorp/go-secure-stdlib/plugincontainer/config"
 	"github.com/hashicorp/go-secure-stdlib/plugincontainer/examples/container/shared"
 )
 
@@ -26,7 +25,7 @@ import (
 // get passed through to the runner's internal config correctly.
 func TestNewContainerRunner_config(t *testing.T) {
 	if runtime.GOOS != "linux" {
-		_, err := NewContainerRunner(hclog.Default(), exec.Command(""), nil, "")
+		_, err := (&Config{}).NewContainerRunner(hclog.Default(), exec.Command(""), "")
 		if err != errUnsupportedOS {
 			t.Fatal(err)
 		}
@@ -36,8 +35,7 @@ func TestNewContainerRunner_config(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	const (
-		gid          = "10"
-		user         = "1000:1000"
+		gid          = 10
 		image        = "fooimage"
 		labelsKey    = "foolabel"
 		runtime      = "fooruntime"
@@ -46,11 +44,21 @@ func TestNewContainerRunner_config(t *testing.T) {
 		memory       = 30
 		endpointsKey = "fooendpoint"
 	)
-	cfg := &config.ContainerConfig{
-		UnixSocketGroup: gid,
-		User:            user,
-		Image:           image,
-		DisableNetwork:  true,
+	var (
+		entrypoint  = []string{"entry", "point"}
+		args        = []string{"--foo=1", "positional"}
+		env         = []string{"x=1", "y=2"}
+		expectedEnv = append([]string{fmt.Sprintf("%s=%s", plugin.EnvUnixSocketDir, pluginSocketDir)}, env...)
+	)
+	cfg := &Config{
+		GroupAdd: gid,
+
+		Entrypoint: entrypoint,
+		Args:       args,
+		Env:        env,
+
+		Image:          image,
+		DisableNetwork: true,
 		Labels: map[string]string{
 			labelsKey: "bar",
 		},
@@ -62,25 +70,37 @@ func TestNewContainerRunner_config(t *testing.T) {
 			endpointsKey: {},
 		},
 	}
-	runner, err := NewContainerRunner(hclog.Default(), exec.Command(""), cfg, tmpDir)
+	runnerIfc, err := cfg.NewContainerRunner(hclog.Default(), exec.Command(""), tmpDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// container.Config
-	if runner.containerConfig.User != user {
-		t.Fatal(runner.containerConfig.User)
+	runner, ok := runnerIfc.(*containerRunner)
+	if !ok {
+		t.Fatal(runner)
 	}
+
+	// container.Config
 	if runner.containerConfig.Image != image {
-		t.Fatal(image)
+		t.Error(image)
+	}
+	if !reflect.DeepEqual(entrypoint, []string(runner.containerConfig.Entrypoint)) {
+		t.Error(entrypoint, runner.containerConfig.Entrypoint)
+	}
+	if !reflect.DeepEqual(args, []string(runner.containerConfig.Cmd)) {
+		t.Error(args, runner.containerConfig.Cmd)
+	}
+	if !reflect.DeepEqual(expectedEnv, []string(runner.containerConfig.Env)) {
+		t.Error(expectedEnv, runner.containerConfig.Env)
 	}
 	if runner.containerConfig.Labels[labelsKey] != "bar" {
-		t.Fatal(runner.containerConfig.Labels)
+		t.Error(runner.containerConfig.Labels)
 	}
 	if runner.containerConfig.NetworkDisabled != true {
-		t.Fatal()
+		t.Error()
 	}
-	var foundUnixSocketGroup, foundUnixSocketDir bool
+	// plugincontainer should override plugin.EnvUnixSocketDir env for the container.
+	var foundUnixSocketDir bool
 	for _, env := range runner.containerConfig.Env {
 		key, value, ok := strings.Cut(env, "=")
 		if !ok {
@@ -89,41 +109,35 @@ func TestNewContainerRunner_config(t *testing.T) {
 		if key == plugin.EnvUnixSocketDir {
 			foundUnixSocketDir = true
 			if value != pluginSocketDir {
-				t.Fatalf("Expected %s to be %s, but got %s", plugin.EnvUnixSocketDir, pluginSocketDir, value)
-			}
-		}
-		if key == plugin.EnvUnixSocketGroup {
-			foundUnixSocketGroup = true
-			if value != gid {
-				t.Fatalf("Expected %s to be %s, but got %s", plugin.EnvUnixSocketGroup, gid, value)
+				t.Errorf("Expected %s to be %s, but got %s", plugin.EnvUnixSocketDir, pluginSocketDir, value)
 			}
 		}
 	}
-	if !foundUnixSocketDir || !foundUnixSocketGroup {
-		t.Fatalf("Expected both unix socket group and dir env vars, but got: %v, %v\nEnv:\n%v",
-			foundUnixSocketDir, foundUnixSocketGroup, runner.containerConfig.Env)
+	if !foundUnixSocketDir {
+		t.Errorf("Expected unix socket dir env var, but got: %v; Env: %v",
+			foundUnixSocketDir, runner.containerConfig.Env)
 	}
 
 	// container.HostConfig
-	if runner.hostConfig.GroupAdd[0] != gid {
-		t.Fatal(runner.hostConfig.GroupAdd)
+	if runner.hostConfig.GroupAdd[0] != fmt.Sprintf("%d", gid) {
+		t.Error(runner.hostConfig.GroupAdd)
 	}
 	if runner.hostConfig.Runtime != runtime {
-		t.Fatal(runner.hostConfig.Runtime)
+		t.Error(runner.hostConfig.Runtime)
 	}
 	if runner.hostConfig.CgroupParent != cgroupParent {
-		t.Fatal(runner.hostConfig.CgroupParent)
+		t.Error(runner.hostConfig.CgroupParent)
 	}
 	if runner.hostConfig.NanoCPUs != nanoCPUs {
-		t.Fatal(runner.hostConfig.NanoCPUs)
+		t.Error(runner.hostConfig.NanoCPUs)
 	}
 	if runner.hostConfig.Memory != memory {
-		t.Fatal(runner.hostConfig.Memory)
+		t.Error(runner.hostConfig.Memory)
 	}
 
 	// network.NetworkingConfig
 	if runner.networkConfig.EndpointsConfig[endpointsKey] == nil {
-		t.Fatal(runner.networkConfig.EndpointsConfig)
+		t.Error(runner.networkConfig.EndpointsConfig)
 	}
 }
 
@@ -176,20 +190,18 @@ func testExamplePlugin_WithRuntime(t *testing.T, ociRuntime string) {
 		"image with tag and id":     {"go-plugin-counter", "latest", id},
 	} {
 		t.Run(name, func(t *testing.T) {
+			cfg := &Config{
+				Image:    tc.image,
+				Tag:      tc.tag,
+				SHA256:   tc.sha256,
+				Runtime:  ociRuntime,
+				GroupAdd: os.Getgid(),
+			}
 			client := plugin.NewClient(&plugin.ClientConfig{
 				HandshakeConfig: shared.Handshake,
 				Plugins:         shared.PluginMap,
 				SkipHostEnv:     true,
 				AutoMTLS:        true,
-				RunnerFunc: func(logger hclog.Logger, cmd *exec.Cmd, tmpDir string) (runner.Runner, error) {
-					cfg := &config.ContainerConfig{
-						Image:           tc.image,
-						SHA256:          tc.sha256,
-						UnixSocketGroup: fmt.Sprintf("%d", os.Getgid()),
-						Runtime:         ociRuntime,
-					}
-					return NewContainerRunner(logger, cmd, cfg, tmpDir)
-				},
 				AllowedProtocols: []plugin.Protocol{
 					plugin.ProtocolGRPC,
 				},
@@ -197,6 +209,10 @@ func testExamplePlugin_WithRuntime(t *testing.T, ociRuntime string) {
 					Name:  t.Name(),
 					Level: hclog.Trace,
 				}),
+				UnixSocketConfig: &plugin.UnixSocketConfig{
+					Group: fmt.Sprintf("%d", cfg.GroupAdd),
+				},
+				RunnerFunc: cfg.NewContainerRunner,
 			})
 			defer client.Kill()
 
@@ -265,12 +281,12 @@ func testExamplePlugin_WithRuntime(t *testing.T, ociRuntime string) {
 			nil,
 			"broken:latest",
 		},
-		// Error should include container environment as part of diagnostics.
+		// Error should include container image as part of diagnostics.
 		"simulated plugin error": {
 			"broken",
 			"",
 			nil,
-			fmt.Sprintf("%s=%s", shared.Handshake.MagicCookieKey, shared.Handshake.MagicCookieValue),
+			"Image: broken",
 		},
 		// The image and sha256 both got built in this test suite, but they
 		// mismatch so error should be SHA256 mismatch.
@@ -282,20 +298,17 @@ func testExamplePlugin_WithRuntime(t *testing.T, ociRuntime string) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
+			cfg := &Config{
+				Image:    tc.image,
+				SHA256:   tc.sha256,
+				Runtime:  ociRuntime,
+				GroupAdd: os.Getgid(),
+			}
 			client := plugin.NewClient(&plugin.ClientConfig{
 				HandshakeConfig: shared.Handshake,
 				Plugins:         shared.PluginMap,
 				SkipHostEnv:     true,
 				AutoMTLS:        true,
-				RunnerFunc: func(logger hclog.Logger, cmd *exec.Cmd, tmpDir string) (runner.Runner, error) {
-					cfg := &config.ContainerConfig{
-						Image:           tc.image,
-						SHA256:          tc.sha256,
-						UnixSocketGroup: fmt.Sprintf("%d", os.Getgid()),
-						Runtime:         ociRuntime,
-					}
-					return NewContainerRunner(logger, cmd, cfg, tmpDir)
-				},
 				AllowedProtocols: []plugin.Protocol{
 					plugin.ProtocolGRPC,
 				},
@@ -303,11 +316,15 @@ func testExamplePlugin_WithRuntime(t *testing.T, ociRuntime string) {
 					Name:  t.Name(),
 					Level: hclog.Trace,
 				}),
+				UnixSocketConfig: &plugin.UnixSocketConfig{
+					Group: fmt.Sprintf("%d", cfg.GroupAdd),
+				},
+				RunnerFunc: cfg.NewContainerRunner,
 			})
 			defer client.Kill()
 
 			// Connect via RPC
-			_, err := client.Client()
+			_, err = client.Client()
 			if err == nil {
 				t.Fatal("Expected error starting fake plugin")
 			}

--- a/plugincontainer/container_runner_test.go
+++ b/plugincontainer/container_runner_test.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"reflect"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -119,7 +120,7 @@ func TestNewContainerRunner_config(t *testing.T) {
 	}
 
 	// container.HostConfig
-	if runner.hostConfig.GroupAdd[0] != fmt.Sprintf("%d", gid) {
+	if runner.hostConfig.GroupAdd[0] != strconv.Itoa(gid) {
 		t.Error(runner.hostConfig.GroupAdd)
 	}
 	if runner.hostConfig.Runtime != runtime {
@@ -210,7 +211,7 @@ func testExamplePlugin_WithRuntime(t *testing.T, ociRuntime string) {
 					Level: hclog.Trace,
 				}),
 				UnixSocketConfig: &plugin.UnixSocketConfig{
-					Group: fmt.Sprintf("%d", cfg.GroupAdd),
+					Group: strconv.Itoa(cfg.GroupAdd),
 				},
 				RunnerFunc: cfg.NewContainerRunner,
 			})
@@ -317,7 +318,7 @@ func testExamplePlugin_WithRuntime(t *testing.T, ociRuntime string) {
 					Level: hclog.Trace,
 				}),
 				UnixSocketConfig: &plugin.UnixSocketConfig{
-					Group: fmt.Sprintf("%d", cfg.GroupAdd),
+					Group: strconv.Itoa(cfg.GroupAdd),
 				},
 				RunnerFunc: cfg.NewContainerRunner,
 			})

--- a/plugincontainer/examples/container/main.go
+++ b/plugincontainer/examples/container/main.go
@@ -34,7 +34,7 @@ func run() error {
 			plugin.ProtocolGRPC,
 		},
 		UnixSocketConfig: &plugin.UnixSocketConfig{
-			Group: fmt.Sprintf("%d", cfg.GroupAdd),
+			Group: strconv.Itoa(cfg.GroupAdd),
 		},
 		RunnerFunc: cfg.NewContainerRunner,
 	})

--- a/plugincontainer/go.mod
+++ b/plugincontainer/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/docker/docker v24.0.5+incompatible
 	github.com/hashicorp/go-hclog v1.5.0
-	github.com/hashicorp/go-plugin v1.5.1-0.20230904131810-817b3dafdeb1
+	github.com/hashicorp/go-plugin v1.5.1
 	google.golang.org/grpc v1.57.0
 	google.golang.org/protobuf v1.31.0
 )

--- a/plugincontainer/go.mod
+++ b/plugincontainer/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/docker/docker v24.0.5+incompatible
 	github.com/hashicorp/go-hclog v1.5.0
-	github.com/hashicorp/go-plugin v1.5.0
+	github.com/hashicorp/go-plugin v1.5.1-0.20230904131810-817b3dafdeb1
 	google.golang.org/grpc v1.57.0
 	google.golang.org/protobuf v1.31.0
 )

--- a/plugincontainer/go.sum
+++ b/plugincontainer/go.sum
@@ -25,8 +25,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/hashicorp/go-hclog v1.5.0 h1:bI2ocEMgcVlz55Oj1xZNBsVi900c7II+fWDyV9o+13c=
 github.com/hashicorp/go-hclog v1.5.0/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
-github.com/hashicorp/go-plugin v1.5.1-0.20230904131810-817b3dafdeb1 h1:zoBtvq0JUBWiYNa1V1rMcy7waZEmFESqUJEf2bHN0pQ=
-github.com/hashicorp/go-plugin v1.5.1-0.20230904131810-817b3dafdeb1/go.mod h1:w1sAEES3g3PuV/RzUrgow20W2uErMly84hhD3um1WL4=
+github.com/hashicorp/go-plugin v1.5.1 h1:oGm7cWBaYIp3lJpx1RUEfLWophprE2EV/KUeqBYo+6k=
+github.com/hashicorp/go-plugin v1.5.1/go.mod h1:w1sAEES3g3PuV/RzUrgow20W2uErMly84hhD3um1WL4=
 github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE=
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
 github.com/jhump/protoreflect v1.15.1 h1:HUMERORf3I3ZdX05WaQ6MIpd/NJ434hTp5YiKgfCL6c=

--- a/plugincontainer/go.sum
+++ b/plugincontainer/go.sum
@@ -25,8 +25,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/hashicorp/go-hclog v1.5.0 h1:bI2ocEMgcVlz55Oj1xZNBsVi900c7II+fWDyV9o+13c=
 github.com/hashicorp/go-hclog v1.5.0/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
-github.com/hashicorp/go-plugin v1.5.0 h1:g6Lj3USwF5LaB8HlvCxPjN2X4nFE08ko2BJNVpl7TIE=
-github.com/hashicorp/go-plugin v1.5.0/go.mod h1:w1sAEES3g3PuV/RzUrgow20W2uErMly84hhD3um1WL4=
+github.com/hashicorp/go-plugin v1.5.1-0.20230904131810-817b3dafdeb1 h1:zoBtvq0JUBWiYNa1V1rMcy7waZEmFESqUJEf2bHN0pQ=
+github.com/hashicorp/go-plugin v1.5.1-0.20230904131810-817b3dafdeb1/go.mod h1:w1sAEES3g3PuV/RzUrgow20W2uErMly84hhD3um1WL4=
 github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE=
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
 github.com/jhump/protoreflect v1.15.1 h1:HUMERORf3I3ZdX05WaQ6MIpd/NJ434hTp5YiKgfCL6c=


### PR DESCRIPTION
This makes several breaking API changes, so will necessitate a bump to v0.2.0, but should provide us with a better API in the longer term.

Builds on the additions in https://github.com/hashicorp/go-plugin/pull/277 to enable dropping all default capabilities from the plugin container. We now let go-plugin set the PLUGIN_UNIX_SOCKET_GROUP env var, and override the value it sets for PLUGIN_UNIX_SOCKET_DIR because the plugin's view of that directory is different. As a result, renamed `UnixSocketGroup` as `GroupAdd` to more accurately reflect that it now only controls the container's GroupAdd setting.

As that requires a breaking change, I also updated the API for creating a RunnerFunc to make it a bit cleaner and reduce unnecessarily exported API surface like `ContainerRunner` which was useless anyway when directly created from outside the package - the best place to see the result of this is in container_runner_test.go or example/bidirectional/main.go.

Lastly this PR also removes the container's env from the Diagnose output, as it could reasonably include secrets. I'm planning to re-add that capability in a separate PR but behind a `Debug` configurable.