### PR TITLE
plugincontainer: Fix container logs context to have no timeout/cancel

### DIFF
--- a/plugincontainer/container_runner.go
+++ b/plugincontainer/container_runner.go
@@ -202,7 +202,9 @@ func (c *containerRunner) Start(ctx context.Context) error {
 	}
 
 	// ContainerLogs combines stdout and stderr.
-	logReader, err := c.dockerClient.ContainerLogs(ctx, c.id, types.ContainerLogsOptions{
+	// Container logs will stream beyond the lifetime of the initial start
+	// context, so we pass it a fresh context with no timeout.
+	logReader, err := c.dockerClient.ContainerLogs(context.Background(), c.id, types.ContainerLogsOptions{
 		Follow:     true,
 		ShowStdout: true,
 		ShowStderr: true,


### PR DESCRIPTION
Found in manual testing of the Vault release 1.15.0-rc1

The context passed to `Start` by go-plugin is cancelled once the plugin has successfully started and communicated its address, but the lifetime of the container log streaming needs to be uncoupled from that. The log streaming will stop when it encounters an EOF error, which will happen when the container is killed.