### PR TITLE
plugincontainer: Support plugins in rootless runtime with nonroot user

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -87,6 +87,9 @@ jobs:
           }
         }
         EOF
+
+        export PATH="$HOME/bin:$PATH"
+        sudo setcap cap_ipc_lock=ep "$(which rootlesskit)"
         systemctl --user restart docker
     
     - name: Test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -89,7 +89,6 @@ jobs:
         EOF
 
         export PATH="$HOME/bin:$PATH"
-        sudo setcap cap_ipc_lock=ep "$(which rootlesskit)"
         systemctl --user restart docker
     
     - name: Test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -58,7 +58,7 @@ jobs:
             "runsc": {
               "path": "/usr/local/bin/runsc",
               "runtimeArgs": [
-                "--host-uds=all"
+                "--host-uds=create"
               ]
             }
           }
@@ -80,7 +80,7 @@ jobs:
             "runsc": {
               "path": "/usr/local/bin/runsc",
               "runtimeArgs": [
-                "--host-uds=all",
+                "--host-uds=create",
                 "--ignore-cgroups"
               ]
             }

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -89,19 +89,6 @@ jobs:
         EOF
         systemctl --user restart docker
     
-    - name: Install rootless podman
-      if: ${{ matrix.module == 'plugincontainer' }}
-      run: |
-        sudo apt-get install -y podman slirp4netns fuse-overlayfs
-        mkdir -p ~/local/bin
-        RUNSC_SCRIPT=~/local/bin/runsc.podman
-        tee "${RUNSC_SCRIPT}" <<EOF
-        #!/bin/bash
-        /usr/local/bin/runsc --host-uds=all --ignore-cgroups "\$@"
-        EOF
-        chmod u+x "${RUNSC_SCRIPT}"
-        podman --runtime "${RUNSC_SCRIPT}" system service -t 0 &
-    
     - name: Test
       run: cd ${{ matrix.module }} && go test ./...
 

--- a/plugincontainer/compatibility_matrix_test.go
+++ b/plugincontainer/compatibility_matrix_test.go
@@ -66,17 +66,6 @@ func TestCompatibilityMatrix(t *testing.T) {
 	}
 }
 
-func skipIfUnsupported(t *testing.T, i matrixInput) {
-	switch {
-	case i.mlock && i.rootlessEngine:
-		if i.containerRuntime == runtimeRunsc {
-			// runsc works in rootless because it has its own userspace implementation of mlockall(2)
-		} else {
-			t.Skip("TODO: These tests should work if the rootless engine is given the IPC_LOCK capability")
-		}
-	}
-}
-
 func setDockerHost(t *testing.T, rootlessEngine bool) {
 	var socketFile string
 	switch {
@@ -92,7 +81,6 @@ func setDockerHost(t *testing.T, rootlessEngine bool) {
 }
 
 func runExamplePlugin(t *testing.T, i matrixInput) {
-	skipIfUnsupported(t, i)
 	setDockerHost(t, i.rootlessEngine)
 
 	imageRef := goPluginCounterImage

--- a/plugincontainer/compatibility_matrix_test.go
+++ b/plugincontainer/compatibility_matrix_test.go
@@ -30,7 +30,7 @@ type matrixInput struct {
 func (m matrixInput) String() string {
 	var s string
 	if m.rootlessEngine {
-		s = "rootless "
+		s = "rootless_"
 	}
 	s += m.containerEngine
 	// Podman does not support configuring the runtime from the SDK.
@@ -84,8 +84,6 @@ func TestCompatibilityMatrix(t *testing.T) {
 
 func skipIfUnsupported(t *testing.T, i matrixInput) {
 	switch {
-	case i.rootlessEngine && i.rootlessUser:
-		t.Skip("Unix socket permissions not yet working for rootless engine + nonroot container user")
 	case i.containerEngine == enginePodman && !i.rootlessEngine:
 		t.Skip("TODO: These tests would pass but CI doesn't have the environment set up yet")
 	case i.mlock && i.rootlessEngine:

--- a/plugincontainer/compatibility_matrix_test.go
+++ b/plugincontainer/compatibility_matrix_test.go
@@ -71,7 +71,7 @@ func skipIfUnsupported(t *testing.T, i matrixInput) {
 	switch {
 	case i.rootlessEngine && i.containerRuntime == runtimeRunc:
 		if i.rootlessUser {
-			t.Skip("runc requires rootlesskit to have DAC_OVERRIDE capability itself, and that's a very powerful capability")
+			t.Skip("runc requires rootlesskit to have DAC_OVERRIDE capability itself, and that undermines being a rootless runtime")
 		} else if i.mlock {
 			t.Skip("TODO: Partially working, but tests not yet reliably and repeatably passing")
 		}
@@ -110,14 +110,15 @@ func runExamplePlugin(t *testing.T, i matrixInput) {
 		Image:    goPluginCounterImage,
 		Tag:      target,
 		Runtime:  i.containerRuntime,
-		GroupAdd: os.Getgid(),
-		Debug:    true,
+		GroupAdd: os.Getegid(),
 		Rootless: i.rootlessEngine && i.rootlessUser,
+		Debug:    true,
 
 		CapIPCLock: i.mlock,
 	}
 	if i.mlock {
 		cfg.Env = append(cfg.Env, "MLOCK=true")
 	}
+
 	exerciseExamplePlugin(t, cfg)
 }

--- a/plugincontainer/compatibility_matrix_test.go
+++ b/plugincontainer/compatibility_matrix_test.go
@@ -83,20 +83,19 @@ func setDockerHost(t *testing.T, rootlessEngine bool) {
 func runExamplePlugin(t *testing.T, i matrixInput) {
 	setDockerHost(t, i.rootlessEngine)
 
-	imageRef := goPluginCounterImage
 	target := "root"
 	if i.rootlessUser {
-		imageRef += ":nonroot"
 		if i.mlock {
 			target = "nonroot-mlock"
 		} else {
 			target = "nonroot"
 		}
 	}
-	runCmd(t, "docker", "build", "--tag="+imageRef, "--target="+target, "--file=examples/container/Dockerfile", "examples/container")
+	runCmd(t, "docker", "build", fmt.Sprintf("--tag=%s:%s", goPluginCounterImage, target), "--target="+target, "--file=examples/container/Dockerfile", "examples/container")
 
 	cfg := &plugincontainer.Config{
 		Image:    goPluginCounterImage,
+		Tag:      target,
 		Runtime:  i.containerRuntime,
 		GroupAdd: os.Getgid(),
 		Debug:    true,
@@ -105,9 +104,6 @@ func runExamplePlugin(t *testing.T, i matrixInput) {
 	}
 	if i.mlock {
 		cfg.Env = append(cfg.Env, "MLOCK=true")
-	}
-	if i.rootlessUser {
-		cfg.Tag = "nonroot"
 	}
 	exerciseExamplePlugin(t, cfg)
 }

--- a/plugincontainer/compatibility_matrix_test.go
+++ b/plugincontainer/compatibility_matrix_test.go
@@ -13,14 +13,11 @@ import (
 )
 
 const (
-	engineDocker = "docker"
-	enginePodman = "podman"
 	runtimeRunc  = "runc"
 	runtimeRunsc = "runsc"
 )
 
 type matrixInput struct {
-	containerEngine  string
 	containerRuntime string
 	rootlessEngine   bool
 	rootlessUser     bool
@@ -32,11 +29,8 @@ func (m matrixInput) String() string {
 	if m.rootlessEngine {
 		s = "rootless_"
 	}
-	s += m.containerEngine
-	// Podman does not support configuring the runtime from the SDK.
-	if m.containerEngine != enginePodman {
-		s += ":" + m.containerRuntime
-	}
+	s += "docker"
+	s += ":" + m.containerRuntime
 	if m.rootlessUser {
 		s += ":" + "nonroot"
 	}
@@ -53,29 +47,19 @@ func TestCompatibilityMatrix(t *testing.T) {
 
 	runCmd(t, "go", "build", "-o=examples/container/go-plugin-counter", "./examples/container/plugin-counter")
 
-	for _, engine := range []string{engineDocker, enginePodman} {
-		for _, runtime := range []string{runtimeRunc, runtimeRunsc} {
-			for _, rootlessEngine := range []bool{true, false} {
-				for _, rootlessUser := range []bool{true, false} {
-					for _, mlock := range []bool{true, false} {
-						if engine == enginePodman && runtime == runtimeRunsc {
-							// Podman does not support configuring the runtime from the SDK,
-							// so only run 1 of the set of runtime test cases against it.
-							// TODO: See if we can run two instances of podman to support one
-							// runtime each.
-							continue
-						}
-						i := matrixInput{
-							containerEngine:  engine,
-							containerRuntime: runtime,
-							rootlessEngine:   rootlessEngine,
-							rootlessUser:     rootlessUser,
-							mlock:            mlock,
-						}
-						t.Run(i.String(), func(t *testing.T) {
-							runExamplePlugin(t, i)
-						})
+	for _, runtime := range []string{runtimeRunc, runtimeRunsc} {
+		for _, rootlessEngine := range []bool{true, false} {
+			for _, rootlessUser := range []bool{true, false} {
+				for _, mlock := range []bool{true, false} {
+					i := matrixInput{
+						containerRuntime: runtime,
+						rootlessEngine:   rootlessEngine,
+						rootlessUser:     rootlessUser,
+						mlock:            mlock,
 					}
+					t.Run(i.String(), func(t *testing.T) {
+						runExamplePlugin(t, i)
+					})
 				}
 			}
 		}
@@ -84,30 +68,22 @@ func TestCompatibilityMatrix(t *testing.T) {
 
 func skipIfUnsupported(t *testing.T, i matrixInput) {
 	switch {
-	case i.containerEngine == enginePodman && !i.rootlessEngine:
-		t.Skip("TODO: These tests would pass but CI doesn't have the environment set up yet")
 	case i.mlock && i.rootlessEngine:
-		if i.containerEngine == engineDocker && i.containerRuntime == runtimeRunsc {
-			// runsc works in rootless because it has its own implementation of mlockall(2)
+		if i.containerRuntime == runtimeRunsc {
+			// runsc works in rootless because it has its own userspace implementation of mlockall(2)
 		} else {
 			t.Skip("TODO: These tests should work if the rootless engine is given the IPC_LOCK capability")
 		}
 	}
 }
 
-func setDockerHost(t *testing.T, containerEngine string, rootlessEngine bool) {
+func setDockerHost(t *testing.T, rootlessEngine bool) {
 	var socketFile string
 	switch {
-	case containerEngine == engineDocker && !rootlessEngine:
+	case !rootlessEngine:
 		socketFile = "/var/run/docker.sock"
-	case containerEngine == engineDocker && rootlessEngine:
+	case rootlessEngine:
 		socketFile = fmt.Sprintf("/run/user/%d/docker.sock", os.Getuid())
-	case containerEngine == enginePodman && !rootlessEngine:
-		socketFile = "/var/run/podman/podman.sock"
-	case containerEngine == enginePodman && rootlessEngine:
-		socketFile = fmt.Sprintf("/run/user/%d/podman/podman.sock", os.Getuid())
-	default:
-		t.Fatalf("Unsupported combination: %s, %v", containerEngine, rootlessEngine)
 	}
 	if _, err := os.Stat(socketFile); err != nil {
 		t.Fatal("Did not find expected socket file:", err)
@@ -117,7 +93,7 @@ func setDockerHost(t *testing.T, containerEngine string, rootlessEngine bool) {
 
 func runExamplePlugin(t *testing.T, i matrixInput) {
 	skipIfUnsupported(t, i)
-	setDockerHost(t, i.containerEngine, i.rootlessEngine)
+	setDockerHost(t, i.rootlessEngine)
 
 	imageRef := goPluginCounterImage
 	target := "root"
@@ -129,10 +105,11 @@ func runExamplePlugin(t *testing.T, i matrixInput) {
 			target = "nonroot"
 		}
 	}
-	runCmd(t, i.containerEngine, "build", "--tag="+imageRef, "--target="+target, "--file=examples/container/Dockerfile", "examples/container")
+	runCmd(t, "docker", "build", "--tag="+imageRef, "--target="+target, "--file=examples/container/Dockerfile", "examples/container")
 
 	cfg := &plugincontainer.Config{
 		Image:    goPluginCounterImage,
+		Runtime:  i.containerRuntime,
 		GroupAdd: os.Getgid(),
 		Debug:    true,
 
@@ -143,9 +120,6 @@ func runExamplePlugin(t *testing.T, i matrixInput) {
 	}
 	if i.rootlessUser {
 		cfg.Tag = "nonroot"
-	}
-	if i.containerEngine != enginePodman {
-		cfg.Runtime = i.containerRuntime
 	}
 	exerciseExamplePlugin(t, cfg)
 }

--- a/plugincontainer/compatibility_matrix_test.go
+++ b/plugincontainer/compatibility_matrix_test.go
@@ -40,34 +40,6 @@ func (m matrixInput) String() string {
 	return s
 }
 
-func withContainerRuntime(s string) func(matrixInput) matrixInput {
-	return func(m matrixInput) matrixInput {
-		m.containerRuntime = s
-		return m
-	}
-}
-
-func withRootlessEngine(b bool) func(matrixInput) matrixInput {
-	return func(m matrixInput) matrixInput {
-		m.rootlessEngine = b
-		return m
-	}
-}
-
-func withRootlessUser(b bool) func(matrixInput) matrixInput {
-	return func(m matrixInput) matrixInput {
-		m.rootlessUser = b
-		return m
-	}
-}
-
-func withMlock(b bool) func(matrixInput) matrixInput {
-	return func(m matrixInput) matrixInput {
-		m.mlock = b
-		return m
-	}
-}
-
 func TestCompatibilityMatrix(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("Only linux is supported for now")
@@ -75,19 +47,19 @@ func TestCompatibilityMatrix(t *testing.T) {
 
 	runCmd(t, "go", "build", "-o=examples/container/go-plugin-counter", "./examples/container/plugin-counter")
 
-	testCases := [][]func(matrixInput) matrixInput{
-		{withRootlessEngine(true), withRootlessEngine(false)},
-		{withContainerRuntime(runtimeRunc), withContainerRuntime(runtimeRunsc)},
-		{withRootlessUser(true), withRootlessUser(false)},
-		{withMlock(true), withMlock(false)},
+	var input matrixInput
+	testCases := [][2]func(){
+		{func() { input.rootlessEngine = true }, func() { input.rootlessEngine = false }},
+		{func() { input.containerRuntime = runtimeRunc }, func() { input.containerRuntime = runtimeRunsc }},
+		{func() { input.rootlessUser = true }, func() { input.rootlessUser = false }},
+		{func() { input.mlock = true }, func() { input.mlock = false }},
 	}
 	// Run a test for all combinations of 4 binary choices.
 	// Use 4 bit numbers to represent all possible choices, e.g.
 	// e.g. 0100 runs rootless_docker:runsc:nonroot:mlock
 	for i := 0; i < 1<<len(testCases); i++ {
-		var input matrixInput
 		for j := 0; j < len(testCases); j++ {
-			input = testCases[j][(i>>j)&1](input)
+			testCases[j][(i>>j)&1]()
 		}
 		t.Run(input.String(), func(t *testing.T) {
 			runExamplePlugin(t, input)

--- a/plugincontainer/config.go
+++ b/plugincontainer/config.go
@@ -11,25 +11,46 @@ import (
 // Currently only compatible with Linux due to the requirements we have for
 // establishing communication over a unix socket.
 //
-// A temporary directory will be mounted into the container and both the host
-// and the plugin will create unix sockets that need to be writable from the
-// other side. To achieve this, there are broadly 2 runtime options (i.e. not
-// including build-time options):
+// A temporary directory will be mounted into the container, which needs to be
+// writable by the plugin so it can create a unix socket, which in turn needs
+// to be writable from the host. To achieve these 2-way write perimissions,
+// this library implements two different strategies:
 //
 //  1. Set up a uid or gid common to both the host and container processes, and
-//     ensure the unix socket is writable by that shared id. Set GroupAdd in this
-//     config and go-plugin ClientConfig's UnixSocketConfig Group with the same
-//     numeric gid to set up a common group. go-plugin will handle making all
-//     sockets writable by the gid.
-//  2. Use a rootless container runtime, in which case the container process will
-//     be run as the same unpriveleged user as the client.
+//     ensure the unix socket is writable by that shared id.
+//
+//     a) For a shared uid, run as root inside the container to avoid being mapped
+//     to a different uid within the user namespace. No need to set GroupAdd or
+//     Rootless options, but note this is highly inadvisable unless your container
+//     runtime is unprivileged/rootless.
+//
+//     b) For a shared gid, use the same numeric gid for GroupAdd in this config
+//     and go-plugin's ClientConfig.UnixSocketConfig.Group. go-plugin will handle
+//     making all sockets writable by the gid. Not sufficient on its own for
+//     rootless runtimes, as the gid will be mapped to a different actual group
+//     inside the container.
+//
+//  2. If the container runtime and the container itself are both configured to
+//     run as non-root users, it's not possible to set up a shared uid or gid.
+//     In this case, set the Rootless option to enable two changes:
+//
+//     a) Enable the DAC_OVERRIDE capability for the container to allow the
+//     plugin to create a file in the shared directory. Note it is recommended
+//     to limit usage of this functionality to gVisor containers, because other
+//     runtimes will need to be given DAC_OVERRIDE themselves, which undermines
+//     some of the benefit of using a rootless container runtime.
+//
+//     b) Apply a default ACL to the shared directory, allowing the host to
+//     write to any socket files created in it. The socket must be group-
+//     writable for the default ACL to take effect, so GroupAdd must also be
+//     set.
 type Config struct {
 	// GroupAdd sets an additional group that the container should run as. Should
-	// match the UnixSocketConfig Group passed to go-plugin. It should be set if
-	// the container runtime runs as root.
+	// match the UnixSocketConfig Group passed to go-plugin.
 	GroupAdd int
 
-	// Rootless is an alternative to GroupAdd, useful for rootless installs. It
+	// Rootless enables extra steps necessary to make the plugin's Unix socket
+	// writable by both sides when using a rootless container runtime. It
 	// should be set if both the host's container runtime and the container
 	// itself are configured to run as non-privileged users. It requires a file
 	// system that supports POSIX 1e ACLs, which should be available by default

--- a/plugincontainer/config.go
+++ b/plugincontainer/config.go
@@ -33,8 +33,7 @@ type Config struct {
 	// should be set if both the host's container runtime and the container
 	// itself are configured to run as non-privileged users. It requires a file
 	// system that supports POSIX 1e ACLs, which should be available by default
-	// on most modern Linux distributions. Users must also enable go-plugin's
-	// plugin.ClientConfig.GRPCBrokerMultiplexing feature.
+	// on most modern Linux distributions.
 	Rootless bool
 
 	// Container command/env

--- a/plugincontainer/config.go
+++ b/plugincontainer/config.go
@@ -25,9 +25,17 @@ import (
 //     be run as the same unpriveleged user as the client.
 type Config struct {
 	// GroupAdd sets an additional group that the container should run as. Should
-	// match the UnixSocketConfig Group passed to go-plugin. Needs to be set if
-	// the container runtime is not rootless.
+	// match the UnixSocketConfig Group passed to go-plugin. It should be set if
+	// the container runtime runs as root.
 	GroupAdd int
+
+	// Rootless is an alternative to GroupAdd, useful for rootless installs. It
+	// should be set if both the host's container runtime and the container
+	// itself are configured to run as non-privileged users. It requires a file
+	// system that supports POSIX 1e ACLs, which should be available by default
+	// on most modern Linux distributions. Users must also enable go-plugin's
+	// plugin.ClientConfig.GRPCBrokerMultiplexing feature.
+	Rootless bool
 
 	// Container command/env
 	Entrypoint []string // If specified, replaces the container entrypoint.

--- a/plugincontainer/container_runner.go
+++ b/plugincontainer/container_runner.go
@@ -217,7 +217,7 @@ func (c *containerRunner) Start(ctx context.Context) error {
 	//
 	// 1. Run as root within the container. The container's root user is not
 	//    mapped to a different host user, so we get:
-	//    Host view: Running as unpriveleged user, folder owned by the same user.
+	//    Host view: Running as unprivileged user, folder owned by the same user.
 	//    Container view: Running ass root, folder owned by root.
 	//
 	// 2. Run as non-root within the container. The container runs as a

--- a/plugincontainer/container_runner.go
+++ b/plugincontainer/container_runner.go
@@ -210,15 +210,16 @@ func (c *containerRunner) Start(ctx context.Context) error {
 	for _, opt := range info.SecurityOptions {
 		if opt == "name=rootless" {
 			rootless = true
+			break
 		}
 	}
 	// If container runtime is rootless, our GroupAdd trick to make the Unix
-	// socket writable from both sides stops working and we have two options:
+	// socket writable from both sides stops working:
 	//
-	// 1. Run as root within the container. The container's root user is not
-	//    mapped to a different host user, so we get:
+	// 1. Run as root within the container still works. The container's root
+	//    user is not mapped to a different host user, so we get:
 	//    Host view: Running as unprivileged user, folder owned by the same user.
-	//    Container view: Running ass root, folder owned by root.
+	//    Container view: Running as root, folder owned by root.
 	//
 	// 2. Run as non-root within the container. The container runs as a
 	//    subordinate uid, with the mapping defined by /etc/subuid. e.g. if the

--- a/plugincontainer/container_runner.go
+++ b/plugincontainer/container_runner.go
@@ -450,7 +450,7 @@ Stderr:
 //
 //  2. Run as non-root within the container fails. The container runs as a
 //     subordinate uid, with the mapping defined by /etc/subuid. e.g. if the host
-//     unprivileged user is 1000(ubuntu), and /etc/subuid has the following entry:
+//     unprivileged user is 1001(ubuntu), and /etc/subuid has the following entry:
 //     ubuntu:100000:65536
 //
 //     Then running as user 1 inside the container will map to user 100000
@@ -466,9 +466,10 @@ Stderr:
 //     To fix the host permissions, we set default permissions on the folder
 //     so any Unix sockets created in it are automatically writable.
 //
-//     To fix the container permissions, we give it the DAC_OVERRIDE capability
+//     To fix the container permissions, we give it the DAC_OVERRIDE capability,
 //     which is normally on by default, and allows the container process to
-//     ignore file system permissions for any files mounted inside the container.
+//     ignore file system permission restrictions. The only bit of the host file
+//     system it has access to though is the empty shared folder.
 //
 //     Similar to mlock and the IPC_LOCK capability, runc requires rootlesskit
 //     (the container's parent process) to have the DAC_OVERRIDE capability
@@ -480,7 +481,7 @@ Stderr:
 // and the host, but the same file permission principles apply.
 func configureDefaultACLsForRootless(hostSocketDir string) error {
 	// Setting default ACLs for the socket folder using unix xattr.
-	a := acl.FromUnix(0o600)
+	a := acl.FromUnix(0o660)
 	a = append(a, acl.Entry{
 		Tag:       acl.TagUser,
 		Qualifier: strconv.Itoa(os.Geteuid()),

--- a/plugincontainer/container_runner.go
+++ b/plugincontainer/container_runner.go
@@ -37,8 +37,6 @@ var (
 	// ErrSHA256Mismatch is returned when starting a container without any
 	// images available where the provided sha256 matches the image and tag.
 	ErrSHA256Mismatch = errors.New("SHA256 mismatch")
-
-	ErrInvalidHostSocketDirectory = errors.New("invalid host socket directory for rootless mode")
 )
 
 const pluginSocketDir = "/tmp/go-plugin-container"
@@ -482,10 +480,10 @@ Stderr:
 // and the host, but the same file permission principles apply.
 func configureDefaultACLsForRootless(hostSocketDir string) error {
 	// Setting default ACLs for the socket folder using unix xattr.
-	a := acl.FromUnix(0o660)
+	a := acl.FromUnix(0o600)
 	a = append(a, acl.Entry{
 		Tag:       acl.TagUser,
-		Qualifier: strconv.Itoa(os.Getuid()),
+		Qualifier: strconv.Itoa(os.Geteuid()),
 		Perms:     0o006,
 	})
 	a = append(a, acl.Entry{

--- a/plugincontainer/container_runner_external_test.go
+++ b/plugincontainer/container_runner_external_test.go
@@ -176,6 +176,10 @@ func testExamplePlugin_WithRuntime(t *testing.T, ociRuntime, id, sha256 string) 
 }
 
 func exerciseExamplePlugin(t *testing.T, cfg *plugincontainer.Config) {
+	tmpDir := t.TempDir()
+	if err := os.Chmod(tmpDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
 	client := plugin.NewClient(&plugin.ClientConfig{
 		HandshakeConfig:     shared.Handshake,
 		Plugins:             shared.PluginMap,
@@ -190,7 +194,8 @@ func exerciseExamplePlugin(t *testing.T, cfg *plugincontainer.Config) {
 			Level: hclog.Trace,
 		}),
 		UnixSocketConfig: &plugin.UnixSocketConfig{
-			Group: strconv.Itoa(cfg.GroupAdd),
+			Group:   strconv.Itoa(cfg.GroupAdd),
+			TempDir: tmpDir,
 		},
 		RunnerFunc: cfg.NewContainerRunner,
 	})

--- a/plugincontainer/container_runner_external_test.go
+++ b/plugincontainer/container_runner_external_test.go
@@ -177,10 +177,11 @@ func testExamplePlugin_WithRuntime(t *testing.T, ociRuntime, id, sha256 string) 
 
 func exerciseExamplePlugin(t *testing.T, cfg *plugincontainer.Config) {
 	client := plugin.NewClient(&plugin.ClientConfig{
-		HandshakeConfig: shared.Handshake,
-		Plugins:         shared.PluginMap,
-		SkipHostEnv:     true,
-		AutoMTLS:        true,
+		HandshakeConfig:     shared.Handshake,
+		Plugins:             shared.PluginMap,
+		SkipHostEnv:         true,
+		AutoMTLS:            true,
+		GRPCBrokerMultiplex: true,
 		AllowedProtocols: []plugin.Protocol{
 			plugin.ProtocolGRPC,
 		},

--- a/plugincontainer/container_runner_external_test.go
+++ b/plugincontainer/container_runner_external_test.go
@@ -176,10 +176,6 @@ func testExamplePlugin_WithRuntime(t *testing.T, ociRuntime, id, sha256 string) 
 }
 
 func exerciseExamplePlugin(t *testing.T, cfg *plugincontainer.Config) {
-	tmpDir := t.TempDir()
-	if err := os.Chmod(tmpDir, 0o750); err != nil {
-		t.Fatal(err)
-	}
 	client := plugin.NewClient(&plugin.ClientConfig{
 		HandshakeConfig:     shared.Handshake,
 		Plugins:             shared.PluginMap,
@@ -194,8 +190,7 @@ func exerciseExamplePlugin(t *testing.T, cfg *plugincontainer.Config) {
 			Level: hclog.Trace,
 		}),
 		UnixSocketConfig: &plugin.UnixSocketConfig{
-			Group:   strconv.Itoa(cfg.GroupAdd),
-			TempDir: tmpDir,
+			Group: strconv.Itoa(cfg.GroupAdd),
 		},
 		RunnerFunc: cfg.NewContainerRunner,
 	})

--- a/plugincontainer/examples/container/Dockerfile
+++ b/plugincontainer/examples/container/Dockerfile
@@ -7,29 +7,7 @@ COPY go-plugin-counter /bin/go-plugin-counter
 
 ENTRYPOINT [ "/bin/go-plugin-counter" ]
 
-# FROM ubuntu as nonroot
-
-# COPY go-plugin-counter /bin/go-plugin-counter
-
-# RUN addgroup --gid 1000 ubuntu
-# RUN adduser --system --uid 1000 --gid 1000 ubuntu
-# RUN chown -R ubuntu:ubuntu /bin/go-plugin-counter
-
-# USER ubuntu
-
 FROM docker.mirror.hashicorp.services/alpine as nonroot
-
-COPY go-plugin-counter /bin/go-plugin-counter
-
-RUN addgroup -S nonroot && \
-    adduser -S -G nonroot nonroot && \
-    chown -R nonroot:nonroot /bin/go-plugin-counter
-
-USER nonroot
-
-ENTRYPOINT [ "/bin/go-plugin-counter" ]
-
-FROM docker.mirror.hashicorp.services/alpine as nonroot-mlock
 
 COPY go-plugin-counter /bin/go-plugin-counter
 
@@ -37,10 +15,16 @@ RUN apk add libcap && \
     addgroup -S nonroot && \
     adduser -S -G nonroot nonroot && \
     chown -R nonroot:nonroot /bin/go-plugin-counter && \
-    setcap cap_ipc_lock=+ep /bin/go-plugin-counter
+    cp /bin/go-plugin-counter /bin/go-plugin-counter-mlock && \
+    setcap cap_ipc_lock=+ep /bin/go-plugin-counter-mlock
 
 USER nonroot
 
 ENTRYPOINT [ "/bin/go-plugin-counter" ]
 
+FROM nonroot as nonroot-mlock
+
+ENTRYPOINT [ "/bin/go-plugin-counter-mlock" ]
+
+# Set root as the default image.
 FROM root

--- a/plugincontainer/examples/container/Dockerfile
+++ b/plugincontainer/examples/container/Dockerfile
@@ -7,6 +7,16 @@ COPY go-plugin-counter /bin/go-plugin-counter
 
 ENTRYPOINT [ "/bin/go-plugin-counter" ]
 
+# FROM ubuntu as nonroot
+
+# COPY go-plugin-counter /bin/go-plugin-counter
+
+# RUN addgroup --gid 1000 ubuntu
+# RUN adduser --system --uid 1000 --gid 1000 ubuntu
+# RUN chown -R ubuntu:ubuntu /bin/go-plugin-counter
+
+# USER ubuntu
+
 FROM docker.mirror.hashicorp.services/alpine as nonroot
 
 COPY go-plugin-counter /bin/go-plugin-counter

--- a/plugincontainer/examples/container/Dockerfile
+++ b/plugincontainer/examples/container/Dockerfile
@@ -7,13 +7,13 @@ COPY go-plugin-counter /bin/go-plugin-counter
 
 ENTRYPOINT [ "/bin/go-plugin-counter" ]
 
-FROM docker.mirror.hashicorp.services/alpine as nonroot
+FROM docker.mirror.hashicorp.services/ubuntu as nonroot
 
 COPY go-plugin-counter /bin/go-plugin-counter
 
-RUN apk add libcap && \
-    addgroup -S nonroot && \
-    adduser -S -G nonroot nonroot && \
+RUN apt-get update && apt-get install -y libcap2-bin acl && \
+    addgroup --system nonroot && \
+    adduser --system --ingroup nonroot nonroot && \
     chown -R nonroot:nonroot /bin/go-plugin-counter && \
     cp /bin/go-plugin-counter /bin/go-plugin-counter-mlock && \
     setcap cap_ipc_lock=+ep /bin/go-plugin-counter-mlock

--- a/plugincontainer/examples/container/plugin-counter/main.go
+++ b/plugincontainer/examples/container/plugin-counter/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"log"
 	"os"
+	"strconv"
 	"syscall"
 
 	"github.com/hashicorp/go-plugin"
@@ -32,7 +33,7 @@ func (c *Counter) Increment(key string, value int64, storage shared.Storage) (in
 }
 
 func main() {
-	if mlock := os.Getenv("MLOCK"); mlock == "true" || mlock == "1" {
+	if mlock, _ := strconv.ParseBool(os.Getenv("MLOCK")); mlock {
 		err := unix.Mlockall(syscall.MCL_CURRENT | syscall.MCL_FUTURE)
 		if err != nil {
 			log.Fatalf("failed to call unix.Mlockall: %s", err)

--- a/plugincontainer/go.mod
+++ b/plugincontainer/go.mod
@@ -5,7 +5,8 @@ go 1.20
 require (
 	github.com/docker/docker v24.0.5+incompatible
 	github.com/hashicorp/go-hclog v1.5.0
-	github.com/hashicorp/go-plugin v1.5.1
+	github.com/hashicorp/go-plugin v1.5.3-0.20231025163852-0b28f225bcb4
+	github.com/joshlf/go-acl v0.0.0-20200411065538-eae00ae38531
 	golang.org/x/sys v0.13.0
 	google.golang.org/grpc v1.57.1
 	google.golang.org/protobuf v1.31.0
@@ -20,6 +21,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/hashicorp/yamux v0.1.1 // indirect
+	github.com/joshlf/testutil v0.0.0-20170608050642-b5d8aa79d93d // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect

--- a/plugincontainer/go.mod
+++ b/plugincontainer/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/docker/docker v24.0.5+incompatible
 	github.com/hashicorp/go-hclog v1.5.0
-	github.com/hashicorp/go-plugin v1.5.3-0.20231025163852-0b28f225bcb4
+	github.com/hashicorp/go-plugin v1.6.0
 	github.com/joshlf/go-acl v0.0.0-20200411065538-eae00ae38531
 	golang.org/x/sys v0.13.0
 	google.golang.org/grpc v1.57.1

--- a/plugincontainer/go.sum
+++ b/plugincontainer/go.sum
@@ -25,8 +25,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/hashicorp/go-hclog v1.5.0 h1:bI2ocEMgcVlz55Oj1xZNBsVi900c7II+fWDyV9o+13c=
 github.com/hashicorp/go-hclog v1.5.0/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
-github.com/hashicorp/go-plugin v1.5.3-0.20231025163852-0b28f225bcb4 h1:b2JsuGJpy64kI8zO7BhnRz5GrZiKhjUEDcysC7fpu8g=
-github.com/hashicorp/go-plugin v1.5.3-0.20231025163852-0b28f225bcb4/go.mod h1:lBS5MtSSBZk0SHc66KACcjjlU6WzEVP/8pwz68aMkCI=
+github.com/hashicorp/go-plugin v1.6.0 h1:wgd4KxHJTVGGqWBq4QPB1i5BZNEx9BR8+OFmHDmTk8A=
+github.com/hashicorp/go-plugin v1.6.0/go.mod h1:lBS5MtSSBZk0SHc66KACcjjlU6WzEVP/8pwz68aMkCI=
 github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE=
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
 github.com/jhump/protoreflect v1.15.1 h1:HUMERORf3I3ZdX05WaQ6MIpd/NJ434hTp5YiKgfCL6c=

--- a/plugincontainer/go.sum
+++ b/plugincontainer/go.sum
@@ -25,11 +25,15 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/hashicorp/go-hclog v1.5.0 h1:bI2ocEMgcVlz55Oj1xZNBsVi900c7II+fWDyV9o+13c=
 github.com/hashicorp/go-hclog v1.5.0/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
-github.com/hashicorp/go-plugin v1.5.1 h1:oGm7cWBaYIp3lJpx1RUEfLWophprE2EV/KUeqBYo+6k=
-github.com/hashicorp/go-plugin v1.5.1/go.mod h1:w1sAEES3g3PuV/RzUrgow20W2uErMly84hhD3um1WL4=
+github.com/hashicorp/go-plugin v1.5.3-0.20231025163852-0b28f225bcb4 h1:b2JsuGJpy64kI8zO7BhnRz5GrZiKhjUEDcysC7fpu8g=
+github.com/hashicorp/go-plugin v1.5.3-0.20231025163852-0b28f225bcb4/go.mod h1:lBS5MtSSBZk0SHc66KACcjjlU6WzEVP/8pwz68aMkCI=
 github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE=
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
 github.com/jhump/protoreflect v1.15.1 h1:HUMERORf3I3ZdX05WaQ6MIpd/NJ434hTp5YiKgfCL6c=
+github.com/joshlf/go-acl v0.0.0-20200411065538-eae00ae38531 h1:hgVxRoDDPtQE68PT4LFvNlPz2nBKd3OMlGKIQ69OmR4=
+github.com/joshlf/go-acl v0.0.0-20200411065538-eae00ae38531/go.mod h1:fqTUQpVYBvhCNIsMXGl2GE9q6z94DIP6NtFKXCSTVbg=
+github.com/joshlf/testutil v0.0.0-20170608050642-b5d8aa79d93d h1:J8tJzRyiddAFF65YVgxli+TyWBi0f79Sld6rJP6CBcY=
+github.com/joshlf/testutil v0.0.0-20170608050642-b5d8aa79d93d/go.mod h1:b+Q3v8Yrg5o15d71PSUraUzYb+jWl6wQMSBXSGS/hv0=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=


### PR DESCRIPTION
Support running as non-root container users under rootless container runtimes.

* Adds a new configuration option `Config.Rootless`, which should be used when both the runtime and the container user are running as non-root. It sets up default ACLs on the host socket directory, and gives the container the DAC_OVERRIDE capability to ensure each side can write to the shared Unix socket and folder despite each being owned by one side and the other side being a different user on the host.
* Pulls in https://github.com/hashicorp/go-plugin/pull/288 and uses the new `GRPCBrokerMultiplexing` option to eliminate host-side sockets and reduce the `--host-uds` flag from `all` to `create`, which means no Unix domain sockets from the host will ever be available inside gVisor containers.
* Stop skipping rootless + nonroot matrix compatibility tests for gVisor
* Drop `podman` tests for now - they are different enough to be a pain but we don't currently have strong requirements to support podman. It could still get re-added at a later date though.