### PR TITLE
plugincontainer: Fix rootless tests

### DIFF
--- a/plugincontainer/examples/container/Dockerfile
+++ b/plugincontainer/examples/container/Dockerfile
@@ -15,8 +15,9 @@ RUN apt-get update && apt-get install -y libcap2-bin acl && \
     addgroup --system nonroot && \
     adduser --system --ingroup nonroot nonroot && \
     chown -R nonroot:nonroot /bin/go-plugin-counter && \
+    setcap cap_dac_override=+ep /bin/go-plugin-counter && \
     cp /bin/go-plugin-counter /bin/go-plugin-counter-mlock && \
-    setcap cap_ipc_lock=+ep /bin/go-plugin-counter-mlock
+    setcap cap_dac_override,cap_ipc_lock=+ep /bin/go-plugin-counter-mlock
 
 USER nonroot
 


### PR DESCRIPTION
It seems like gVisor fixed a bug where a file's capabilities weren't being properly applied when creating the process: https://github.com/google/gvisor/commit/586c38d70081b13b2ed494cef48e99b93956843e

I haven't fully finished investigating yet, but I think it's the above commit that caused the tests to start failing once it got released and used in CI.