### PR TITLE
plugincontainer: fix docker options

### DIFF
--- a/plugincontainer/container_runner.go
+++ b/plugincontainer/container_runner.go
@@ -215,14 +215,14 @@ func (c *containerRunner) Start(ctx context.Context) error {
 	c.id = resp.ID
 	c.logger.Trace("created container", "image", c.image, "id", c.id)
 
-	if err := c.dockerClient.ContainerStart(ctx, c.id, types.ContainerStartOptions{}); err != nil {
+	if err := c.dockerClient.ContainerStart(ctx, c.id, container.StartOptions{}); err != nil {
 		return fmt.Errorf("error starting container: %w", err)
 	}
 
 	// ContainerLogs combines stdout and stderr.
 	// Container logs will stream beyond the lifetime of the initial start
 	// context, so we pass it a fresh context with no timeout.
-	logReader, err := c.dockerClient.ContainerLogs(context.Background(), c.id, types.ContainerLogsOptions{
+	logReader, err := c.dockerClient.ContainerLogs(context.Background(), c.id, container.LogsOptions{
 		Follow:     true,
 		ShowStdout: true,
 		ShowStderr: true,
@@ -279,7 +279,7 @@ func (c *containerRunner) Kill(ctx context.Context) error {
 	if c.id != "" {
 		if c.debug {
 			defer func() {
-				err := c.dockerClient.ContainerRemove(ctx, c.id, types.ContainerRemoveOptions{
+				err := c.dockerClient.ContainerRemove(ctx, c.id, container.RemoveOptions{
 					Force: true,
 				})
 				if err != nil {
@@ -414,7 +414,7 @@ Check stdout in the logs below.
 }
 
 func (c *containerRunner) diagnoseLogs(ctx context.Context) string {
-	logReader, err := c.dockerClient.ContainerLogs(ctx, c.id, types.ContainerLogsOptions{
+	logReader, err := c.dockerClient.ContainerLogs(ctx, c.id, container.LogsOptions{
 		ShowStdout: true,
 		ShowStderr: true,
 		Follow:     false,


### PR DESCRIPTION
The docker module (provided by The Moby Project) has removed obsoleted function options, and replaced them with the ones from container module.

Reference: https://github.com/moby/moby/commit/13f46948dd57c9530906789de2732ab9dd13d004