### PR TITLE
plugincontainer: fix image build

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -49,7 +49,7 @@ jobs:
         (
           set -e
           ARCH="$(uname -m)"
-          URL="https://storage.googleapis.com/gvisor/releases/release/latest/${ARCH}"
+          URL="https://storage.googleapis.com/gvisor/releases/release/20240311/${ARCH}"
           wget --quiet "${URL}/runsc" "${URL}/runsc.sha512" \
             "${URL}/containerd-shim-runsc-v1" "${URL}/containerd-shim-runsc-v1.sha512"
           sha512sum -c runsc.sha512 \

--- a/plugincontainer/examples/container/Dockerfile
+++ b/plugincontainer/examples/container/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y libcap2-bin acl && \
     groupadd --system nonroot && \
     useradd --system -g nonroot nonroot && \
     chown -R nonroot:nonroot /bin/go-plugin-counter && \
-    cmod 0755 /bin/go-plugin-counter && \
+    chmod 0755 /bin/go-plugin-counter && \
     cp /bin/go-plugin-counter /bin/go-plugin-counter-mlock && \
     setcap cap_ipc_lock=+ep /bin/go-plugin-counter-mlock
 

--- a/plugincontainer/examples/container/Dockerfile
+++ b/plugincontainer/examples/container/Dockerfile
@@ -7,6 +7,7 @@ COPY go-plugin-counter /bin/go-plugin-counter
 
 ENTRYPOINT [ "/bin/go-plugin-counter" ]
 
+# This is docker.mirror.hashicorp.services/ubuntu:24.04 as of 2024-07-31.
 FROM docker.mirror.hashicorp.services/ubuntu@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30 as nonroot
 
 COPY go-plugin-counter /bin/go-plugin-counter
@@ -15,7 +16,6 @@ RUN apt-get update && apt-get install -y libcap2-bin acl && \
     groupadd --system nonroot && \
     useradd --system -g nonroot nonroot && \
     chown -R nonroot:nonroot /bin/go-plugin-counter && \
-    chmod 0755 /bin/go-plugin-counter && \
     cp /bin/go-plugin-counter /bin/go-plugin-counter-mlock && \
     setcap cap_ipc_lock=+ep /bin/go-plugin-counter-mlock
 

--- a/plugincontainer/examples/container/Dockerfile
+++ b/plugincontainer/examples/container/Dockerfile
@@ -7,13 +7,13 @@ COPY go-plugin-counter /bin/go-plugin-counter
 
 ENTRYPOINT [ "/bin/go-plugin-counter" ]
 
-FROM docker.mirror.hashicorp.services/ubuntu as nonroot
+FROM docker.mirror.hashicorp.services/ubuntu@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30 as nonroot
 
 COPY go-plugin-counter /bin/go-plugin-counter
 
 RUN apt-get update && apt-get install -y libcap2-bin acl && \
-    addgroup --system nonroot && \
-    adduser --system --ingroup nonroot nonroot && \
+    groupadd --system nonroot && \
+    useradd --system -g nonroot nonroot && \
     chown -R nonroot:nonroot /bin/go-plugin-counter && \
     cp /bin/go-plugin-counter /bin/go-plugin-counter-mlock && \
     setcap cap_ipc_lock=+ep /bin/go-plugin-counter-mlock

--- a/plugincontainer/examples/container/Dockerfile
+++ b/plugincontainer/examples/container/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y libcap2-bin acl && \
     groupadd --system nonroot && \
     useradd --system -g nonroot nonroot && \
     chown -R nonroot:nonroot /bin/go-plugin-counter && \
+    cmod 0755 /bin/go-plugin-counter && \
     cp /bin/go-plugin-counter /bin/go-plugin-counter-mlock && \
     setcap cap_ipc_lock=+ep /bin/go-plugin-counter-mlock
 


### PR DESCRIPTION
Lock the image version used in test, and switch to available commands