### PR TITLE
Add cryptoutil/rsa, RSA key generation using a seeded DRBG

### DIFF
--- a/cryptoutil/go.mod
+++ b/cryptoutil/go.mod
@@ -1,0 +1,11 @@
+module github.com/hashicorp/go-secure-stdlib/rsa
+
+go 1.23.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/hashicorp/go-hmac-drbg v0.0.0-20210916214228-a6e5a68489f6 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.9.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/cryptoutil/go.sum
+++ b/cryptoutil/go.sum
@@ -1,0 +1,15 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/hashicorp/go-hmac-drbg v0.0.0-20210916214228-a6e5a68489f6 h1:kBoJV4Xl5FLtBfnBjDvBxeNSy2IRITSGs73HQsFUEjY=
+github.com/hashicorp/go-hmac-drbg v0.0.0-20210916214228-a6e5a68489f6/go.mod h1:y+HSOcOGB48PkUxNyLAiCiY6rEENu+E+Ss4LG8QHwf4=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/cryptoutil/rsa.go
+++ b/cryptoutil/rsa.go
@@ -1,0 +1,32 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package cryptoutil
+
+import (
+	"crypto/rsa"
+	"io"
+
+	"github.com/hashicorp/go-hmac-drbg/hmacdrbg"
+)
+
+// GenerateRSAKeyWithHMACDRBG generates an RSA key with a deterministic random bit generator, seeded
+// with entropy from the provided random source.  Some random bit sources are quite slow, for example
+// HSMs with true RNGs can take 500ms to produce enough bits to generate a single number
+// to test for primality, taking literally minutes to succeed in generating a key.
+//
+// Instead, this function seeds a DRBG (specifically HMAC-DRBG from NIST SP800-90a) with
+// entropy from a random source, then uses the output of that DRBG to generate candidate primes.
+// This is still secure as the output of a DRBG is secure if the seed is sufficiently random, and
+// an attacker cannot predict which numbers are chosen for primes if they don't have access to the seed.
+// Additionally, the seed in this case is quite large indeed, 1000 bits, well above what could be brute
+// forced.
+func GenerateRSAKeyWithHMACDRBG(rand io.Reader, bits int) (*rsa.PrivateKey, error) {
+	seed := make([]byte, hmacdrbg.MaxEntropyBytes)
+	if _, err := rand.Read(seed); err != nil {
+		return nil, err
+	}
+	drbg := hmacdrbg.NewHmacDrbg(256, seed, []byte("generate-key-with-hmac-drbg"))
+	reader := hmacdrbg.NewHmacDrbgReader(drbg)
+	return rsa.GenerateKey(reader, bits)
+}

--- a/cryptoutil/rsa.go
+++ b/cryptoutil/rsa.go
@@ -4,8 +4,8 @@
 package cryptoutil
 
 import (
-	"crypto/rsa"
 	"crypto/rand"
+	"crypto/rsa"
 	"io"
 
 	"github.com/hashicorp/go-hmac-drbg/hmacdrbg"
@@ -30,11 +30,11 @@ var platformReader = rand.Reader
 //
 // This is a sanctioned approach from FIPS 186-4 (B.3.2)
 func GenerateRSAKeyWithHMACDRBG(rand io.Reader, bits int) (*rsa.PrivateKey, error) {
-	seed := make([]byte, (2 * 256) / 8) // 2x maximum security strength from SP 800-57, Table 2
+	seed := make([]byte, (2*256)/8) // 2x maximum security strength from SP 800-57, Table 2
 	defer func() {
 		// This may not work due to the GC but worth a shot
-		for i := 0; i<len(seed); i++ {
-			seed[i]=0
+		for i := 0; i < len(seed); i++ {
+			seed[i] = 0
 		}
 	}()
 	for {
@@ -55,11 +55,12 @@ func GenerateRSAKeyWithHMACDRBG(rand io.Reader, bits int) (*rsa.PrivateKey, erro
 	}
 }
 
-// GenerateRSAKey tests whether the random source is rand.Reader, and uses it directly if so (as it will 
+// GenerateRSAKey tests whether the random source is rand.Reader, and uses it directly if so (as it will
 // be a platform RNG and fast.  If not, we assume it's some other slower source and use the HmacDRBG version.
 func GenerateRSAKey(randomSource io.Reader, bits int) (*rsa.PrivateKey, error) {
 	if randomSource == platformReader {
 		return rsa.GenerateKey(randomSource, bits)
 	}
+
 	return GenerateRSAKeyWithHMACDRBG(randomSource, bits)
 }

--- a/cryptoutil/rsa.go
+++ b/cryptoutil/rsa.go
@@ -13,7 +13,9 @@ import (
 // GenerateRSAKeyWithHMACDRBG generates an RSA key with a deterministic random bit generator, seeded
 // with entropy from the provided random source.  Some random bit sources are quite slow, for example
 // HSMs with true RNGs can take 500ms to produce enough bits to generate a single number
-// to test for primality, taking literally minutes to succeed in generating a key.
+// to test for primality, taking literally minutes to succeed in generating a key.  As an example, when
+// testing this function, one run took 921 attempts to generate a 2048 bit RSA key, which would have taken
+// over 7 minutes on a Thales HSM, vs
 //
 // Instead, this function seeds a DRBG (specifically HMAC-DRBG from NIST SP800-90a) with
 // entropy from a random source, then uses the output of that DRBG to generate candidate primes.

--- a/cryptoutil/rsa_test.go
+++ b/cryptoutil/rsa_test.go
@@ -16,10 +16,8 @@ type slowRand struct {
 }
 
 func newSlowRand() *slowRand {
-	r := bytes.NewBuffer(nil)
-	b := make([]byte, 2000*128)
+	b := make([]byte, 10247680)
 	rand.Read(b)
-	r.Write(b)
 	sr := &slowRand{
 		randomBytes: b,
 	}
@@ -28,10 +26,16 @@ func newSlowRand() *slowRand {
 }
 
 func (s *slowRand) Reset() {
+	s.calls = 0
 	s.randomness = bytes.NewBuffer(s.randomBytes)
 }
 
-var sr = newSlowRand()
+
+var sr *slowRand
+func TestMain(m *testing.M) {
+	sr = newSlowRand()
+	m.Run()
+}
 
 func (s *slowRand) Read(p []byte) (n int, err error) {
 	// First one is free
@@ -48,14 +52,26 @@ func TestGenerateKeyWithHMACDRBG(t *testing.T) {
 	key, err := GenerateRSAKeyWithHMACDRBG(rand.Reader, 2048)
 	require.NoError(t, err)
 	require.Equal(t, 2048/8, key.Size())
+	key, err = GenerateRSAKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	require.Equal(t, 2048/8, key.Size())
 }
 
 func BenchmarkRSAKeyGeneration(b *testing.B) {
 	sr.Reset()
 	for i := 0; i < b.N; i++ {
 		rsa.GenerateKey(sr, 2048)
+		b.Logf("%d calls to the RNG, b.N=%d", sr.calls, b.N)
 	}
-	b.Logf("%d calls to the RNG", sr.calls)
+}
+
+func BenchmarkConditionalRSAKeyGeneration(b *testing.B) {
+	platformReader = sr
+	sr.Reset()
+	for i := 0; i < b.N; i++ {
+		GenerateRSAKey(sr, 2048)
+		b.Logf("%d calls to the RNG, b.N=%d", sr.calls, b.N)
+	}
 }
 
 func BenchmarkRSAKeyGenerationWithDRBG(b *testing.B) {
@@ -63,7 +79,7 @@ func BenchmarkRSAKeyGenerationWithDRBG(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		sr.calls = 0
 		GenerateRSAKeyWithHMACDRBG(sr, 2048)
+		b.Logf("%d calls to the RNG, b.N=%d", sr.calls, b.N)
 	}
-	b.Logf("%d calls to the RNG", sr.calls)
 
 }

--- a/cryptoutil/rsa_test.go
+++ b/cryptoutil/rsa_test.go
@@ -1,6 +1,7 @@
 package cryptoutil
 
 import (
+	"bytes"
 	"crypto/rand"
 	"crypto/rsa"
 	"github.com/stretchr/testify/require"
@@ -9,16 +10,38 @@ import (
 )
 
 type slowRand struct {
-	calls int
+	randomness  *bytes.Buffer
+	randomBytes []byte
+	calls       int
 }
+
+func newSlowRand() *slowRand {
+	r := bytes.NewBuffer(nil)
+	b := make([]byte, 2000*128)
+	rand.Read(b)
+	r.Write(b)
+	sr := &slowRand{
+		randomBytes: b,
+	}
+	sr.Reset()
+	return sr
+}
+
+func (s *slowRand) Reset() {
+	s.randomness = bytes.NewBuffer(s.randomBytes)
+}
+
+var sr = newSlowRand()
 
 func (s *slowRand) Read(p []byte) (n int, err error) {
 	// First one is free
 	if s.calls > 0 {
 		time.Sleep(50 * time.Millisecond)
 	}
+
+	n, _ = s.randomness.Read(p)
 	s.calls++
-	return rand.Read(p)
+	return
 }
 
 func TestGenerateKeyWithHMACDRBG(t *testing.T) {
@@ -28,18 +51,19 @@ func TestGenerateKeyWithHMACDRBG(t *testing.T) {
 }
 
 func BenchmarkRSAKeyGeneration(b *testing.B) {
-	var r slowRand
+	sr.Reset()
 	for i := 0; i < b.N; i++ {
-		rsa.GenerateKey(&r, 2048)
+		rsa.GenerateKey(sr, 2048)
 	}
-	b.Logf("%d calls to the RNG", r.calls)
+	b.Logf("%d calls to the RNG", sr.calls)
 }
 
 func BenchmarkRSAKeyGenerationWithDRBG(b *testing.B) {
-	var r slowRand
+	sr.Reset()
 	for i := 0; i < b.N; i++ {
-		GenerateRSAKeyWithHMACDRBG(&r, 2048)
+		sr.calls = 0
+		GenerateRSAKeyWithHMACDRBG(sr, 2048)
 	}
-	b.Logf("%d calls to the RNG", r.calls)
+	b.Logf("%d calls to the RNG", sr.calls)
 
 }

--- a/cryptoutil/rsa_test.go
+++ b/cryptoutil/rsa_test.go
@@ -1,0 +1,45 @@
+package cryptoutil
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+type slowRand struct {
+	calls int
+}
+
+func (s *slowRand) Read(p []byte) (n int, err error) {
+	// First one is free
+	if s.calls > 0 {
+		time.Sleep(50 * time.Millisecond)
+	}
+	s.calls++
+	return rand.Read(p)
+}
+
+func TestGenerateKeyWithHMACDRBG(t *testing.T) {
+	key, err := GenerateRSAKeyWithHMACDRBG(rand.Reader, 2048)
+	require.NoError(t, err)
+	require.Equal(t, 2048/8, key.Size())
+}
+
+func BenchmarkRSAKeyGeneration(b *testing.B) {
+	var r slowRand
+	for i := 0; i < b.N; i++ {
+		rsa.GenerateKey(&r, 2048)
+	}
+	b.Logf("%d calls to the RNG", r.calls)
+}
+
+func BenchmarkRSAKeyGenerationWithDRBG(b *testing.B) {
+	var r slowRand
+	for i := 0; i < b.N; i++ {
+		GenerateRSAKeyWithHMACDRBG(&r, 2048)
+	}
+	b.Logf("%d calls to the RNG", r.calls)
+
+}


### PR DESCRIPTION
In Vault with entropy augmentation, we may be sourcing randomness from a
particularly slow HSM.  RSA needs a lot of randomness to choose primes, and
some customers have seen multiple minute key generation times as a result.

This PR implements RSA key generation where a NIST HMAC DRBG is seeded
from the random source, which is then used to sample unpredictable primes,
resulting in a 5000 - 20000x increase in performance on these slow HSMs.

Additionally, these functions test whether the underlying random source
is crypto/rand, and if so, skips this process and behaves as before.