### PR TITLE
fix(awsutil): only set AssumeRole ExternalID when provided

### DIFF
--- a/awsutil/generate_credentials.go
+++ b/awsutil/generate_credentials.go
@@ -254,7 +254,9 @@ func (c *CredentialsConfig) generateAwsConfigOptions(ctx context.Context, opts o
 			assumeRoleCred := config.WithAssumeRoleCredentialOptions(func(options *stscreds.AssumeRoleOptions) {
 				options.RoleARN = c.RoleARN
 				options.RoleSessionName = c.RoleSessionName
-				options.ExternalID = aws.String(c.RoleExternalId)
+				if c.RoleExternalId != "" {
+					options.ExternalID = aws.String(c.RoleExternalId)
+				}
 				for k, v := range c.RoleTags {
 					options.Tags = append(options.Tags, types.Tag{
 						Key:   aws.String(k),

--- a/awsutil/generate_credentials_test.go
+++ b/awsutil/generate_credentials_test.go
@@ -475,6 +475,25 @@ func TestGenerateAwsConfigOptions(t *testing.T) {
 			},
 		},
 		{
+			name: "assume role credential without external id",
+			cfg: func() *CredentialsConfig {
+				credCfg, err := NewCredentialsConfig(
+					WithRoleArn("foo"),
+					WithRoleSessionName("bar"),
+				)
+				require.NoError(t, err)
+				return credCfg
+			}(),
+			expectedLoadOptions: config.LoadOptions{
+				Region: "us-east-1",
+			},
+			expectedAssumeRoleOptions: &stscreds.AssumeRoleOptions{
+				RoleARN:         "foo",
+				RoleSessionName: "bar",
+				ExternalID:      nil,
+			},
+		},
+		{
 			name: "static credential",
 			cfg: func() *CredentialsConfig {
 				credCfg, err := NewCredentialsConfig(


### PR DESCRIPTION
## Summary

The non-web-identity AssumeRole path in `awsutil/generate_credentials.go` set `options.ExternalID` unconditionally:

```go
options.ExternalID = aws.String(c.RoleExternalId)
```

When no external ID is configured, `aws.String("")` is a non-nil pointer to an empty string, which the SDK serializes as `ExternalId=""` on the `sts:AssumeRole` call. STS rejects it with:

```
ValidationError: ... Value '' at 'externalId' failed to satisfy constraint:
Member must have length greater than or equal to 2
```

This breaks role assumption for any caller that does not use an external ID.

## Fix

Only assign `ExternalID` when a non-empty value was provided. This matches the existing empty-value handling for `RoleExternalId` elsewhere in the file (line 149) and leaves `AssumeRoleOptions.ExternalID` as `nil` when unset, so no `ExternalId` parameter is sent to STS.

Only the plain (non-web-identity) AssumeRole path is affected; the web-identity branches never set `ExternalID`.

Fixes: #185

## Context

Surfaced downstream in `terraform-provider-vault` (hashicorp/terraform-provider-vault#2922, fix in hashicorp/terraform-provider-vault#2923). The provider change stops routing non-web-identity assumption through `WithRoleArn`, which incidentally avoids this code path; this PR fixes the underlying library defect so other consumers are protected.

## Notes for maintainers

- The `awsutil` module has no `CHANGELOG` file, so no changelog entry was added.  Happy to add one if you keep release notes elsewhere.
- Per `CONTRIBUTING`, flagging that this touches credential/AssumeRole behavior used across multiple products; reviewers from affected teams welcome. The change is intentionally minimal and behavior-preserving when an external ID *is* provided.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.

  Examples of changes to controls include access controls, encryption, logging, etc.

- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.

  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.
