### PR TITLE
Support AIX in mlock package

### DIFF
--- a/mlock/mlock_unavail.go
+++ b/mlock/mlock_unavail.go
@@ -1,8 +1,8 @@
 // Copyright IBM Corp. 2020, 2025
 // SPDX-License-Identifier: MPL-2.0
 
-//go:build darwin || nacl || netbsd || plan9 || windows || js
-// +build darwin nacl netbsd plan9 windows js
+//go:build !aix && !dragonfly && !freebsd && !linux && !openbsd && !solaris
+// +build !aix,!dragonfly,!freebsd,!linux,!openbsd,!solaris
 
 package mlock
 

--- a/mlock/mlock_unix.go
+++ b/mlock/mlock_unix.go
@@ -1,7 +1,8 @@
 // Copyright IBM Corp. 2020, 2025
 // SPDX-License-Identifier: MPL-2.0
 
-// +build dragonfly freebsd linux openbsd solaris
+//go:build aix || dragonfly || freebsd || linux || openbsd || solaris
+// +build aix dragonfly freebsd linux openbsd solaris
 
 package mlock
 


### PR DESCRIPTION
👋 Hello, this PR adds `aix` to the list of build tags in `mlock/mlock_unix.go`, and updates the fallback file `mlock/mlock_unavail.go` to use the negated list of build tags from `mlock/mlock_unix.go`.

Currently, `aix` is missing from both files, so the package fails to compile on AIX.
Those changes fix it, and using the negated list as a fallback prevents issues for new operating systems supported by Go.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.

  Examples of changes to controls include access controls, encryption, logging, etc.

- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.

  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.
