### PR TITLE
mlock, password: add aix to unix build constraints

### DIFF
--- a/mlock/mlock_unix.go
+++ b/mlock/mlock_unix.go
@@ -1,7 +1,8 @@
 // Copyright IBM Corp. 2020, 2025
 // SPDX-License-Identifier: MPL-2.0
 
-// +build dragonfly freebsd linux openbsd solaris
+//go:build aix || dragonfly || freebsd || linux || openbsd || solaris
+// +build aix dragonfly freebsd linux openbsd solaris
 
 package mlock
 

--- a/password/password_unix.go
+++ b/password/password_unix.go
@@ -1,8 +1,8 @@
 // Copyright IBM Corp. 2020, 2025
 // SPDX-License-Identifier: MPL-2.0
 
-//go:build linux || darwin || freebsd || netbsd || openbsd || dragonfly || js
-// +build linux darwin freebsd netbsd openbsd dragonfly js
+//go:build linux || darwin || freebsd || netbsd || openbsd || dragonfly || js || aix
+// +build linux darwin freebsd netbsd openbsd dragonfly js aix
 
 package password
 


### PR DESCRIPTION
## Summary

Adds `aix` to the build constraints of `mlock/mlock_unix.go` and `password/password_unix.go` so both modules compile for `GOOS=aix GOARCH=ppc64`.

Fixes #189

## Background

Both packages currently fail on AIX with `undefined: lockMemory` / `undefined: read` — the platform falls through to no implementation. The syscalls used by the unix implementations are available on aix/ppc64 with the stock Go toolchain; no aix-specific code is needed, only the constraint.

This patch has been validated by the IBM Power integration team, who have been carrying it as a fork patch for AIX builds of the Vault CLI/Agent (credited as commit co-author).

## Testing

- `GOOS=aix GOARCH=ppc64 go build ./...` in both `mlock/` and `password/` — compiles
- Native `go build` / `go vet` / `go test` — unchanged, green
- No behavior change on any currently supported platform (constraint-only change; `mlock_unavail.go` still covers darwin/windows/etc.)