### PR TITLE
fix(kv-builder): treat @args as files before splitting on =

### DIFF
--- a/kv-builder/builder.go
+++ b/kv-builder/builder.go
@@ -51,36 +51,34 @@ func (b *Builder) add(raw string) error {
 		return nil
 	}
 
-	// Split into key/value
-	parts := strings.SplitN(raw, "=", 2)
-
 	// If the arg is exactly "-", then we need to read from stdin
 	// and merge the results into the resulting structure.
-	if len(parts) == 1 {
-		if raw == "-" {
-			if b.Stdin == nil {
-				return fmt.Errorf("stdin is not supported")
-			}
-			if b.stdin {
-				return fmt.Errorf("stdin already consumed")
-			}
-
-			b.stdin = true
-			return b.addReader(b.Stdin)
+	if raw == "-" {
+		if b.Stdin == nil {
+			return fmt.Errorf("stdin is not supported")
+		}
+		if b.stdin {
+			return fmt.Errorf("stdin already consumed")
 		}
 
-		// If the arg begins with "@" then we need to read a file directly
-		if raw[0] == '@' {
-			f, err := os.Open(raw[1:])
-			if err != nil {
-				return err
-			}
-			defer f.Close()
-
-			return b.addReader(f)
-		}
+		b.stdin = true
+		return b.addReader(b.Stdin)
 	}
 
+	// If the arg begins with "@" then we need to read a file directly.
+	// Filenames may contain '=', so this must run before splitting.
+	if raw[0] == '@' {
+		f, err := os.Open(raw[1:])
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		return b.addReader(f)
+	}
+
+	// Split into key/value
+	parts := strings.SplitN(raw, "=", 2)
 	if len(parts) != 2 {
 		return fmt.Errorf("format must be key=value")
 	}

--- a/kv-builder/builder_test.go
+++ b/kv-builder/builder_test.go
@@ -5,6 +5,8 @@ package kvbuilder
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 )
@@ -142,15 +144,37 @@ func TestBuilder_sameKeyMultipleTimes(t *testing.T) {
 func TestBuilder_specialCharactersInKey(t *testing.T) {
 	var b Builder
 	b.Stdin = bytes.NewBufferString("{\"foo\": \"bay\"}")
-	err := b.Add("@foo=bar", "-foo=baz", "-")
+	err := b.Add("-foo=baz", "-")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
 	expected := map[string]interface{}{
-		"@foo": "bar",
 		"-foo": "baz",
 		"foo":  "bay",
+	}
+	actual := b.Map()
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("bad: %#v", actual)
+	}
+}
+
+func TestBuilder_fileWithEqualsInName(t *testing.T) {
+	dir := t.TempDir()
+	filename := filepath.Join(dir, "cn=foo,o=example.com.json")
+	contents := []byte(`{"policies":["role.terraform"]}`)
+	if err := os.WriteFile(filename, contents, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var b Builder
+	err := b.Add("@" + filename)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	expected := map[string]interface{}{
+		"policies": []interface{}{"role.terraform"},
 	}
 	actual := b.Map()
 	if !reflect.DeepEqual(actual, expected) {


### PR DESCRIPTION
## Summary
`Builder.add()` split on `=` before handling a leading `@` as a file path, so `@cn=foo,o=example.com.json` was parsed as key `@cn` instead of reading that file. Handle `@` (and `-` stdin) before the split.

Fixes #5

## Test plan
- [x] `cd kv-builder && go test ./...`
- [x] New test `TestBuilder_fileWithEqualsInName` with a temp file whose name contains `=`